### PR TITLE
Add: New stats and config updates for Python

### DIFF
--- a/python/lib.cpp
+++ b/python/lib.cpp
@@ -405,6 +405,9 @@ template <typename index_at> void save_index(index_at const& index, std::string 
 template <typename index_at> void load_index(index_at& index, std::string const& path) { index.load(path.c_str()); }
 template <typename index_at> void view_index(index_at& index, std::string const& path) { index.view(path.c_str()); }
 template <typename index_at> void clear_index(index_at& index) { index.clear(); }
+template <typename index_at> std::size_t get_expansion_add(index_at const &index) { return index.config().expansion_add; }
+template <typename index_at> std::size_t get_expansion_search(index_at const &index) { return index.config().expansion_search; }
+
 // clang-format on
 
 template <typename element_at> bool has_duplicates(element_at const* begin, element_at const* end) {
@@ -522,6 +525,10 @@ PYBIND11_MODULE(index, m) {
     i.def_property_readonly("capacity", &punned_py_t::capacity);
     i.def_property_readonly( //
         "dtype", [](punned_py_t const& index) -> std::string { return accuracy_name(index.accuracy()); });
+    i.def_property_readonly("memory_usage", &punned_py_t::memory_usage);
+
+    i.def_property("expansion_add", &get_expansion_add<punned_py_t>, &punned_py_t::change_expansion_add);
+    i.def_property("expansion_search", &get_expansion_search<punned_py_t>, &punned_py_t::change_expansion_search);
 
     i.def("save", &save_index<punned_py_t>, py::arg("path"));
     i.def("load", &load_index<punned_py_t>, py::arg("path"));

--- a/src/punned.hpp
+++ b/src/punned.hpp
@@ -455,6 +455,8 @@ class punned_gt {
     std::size_t capacity() const { return typed_->capacity(); }
     config_t const& config() const { return typed_->config(); }
     void clear() { return typed_->clear(); }
+    void change_expansion_add(std::size_t n) noexcept { typed_->change_expansion_add(n); }
+    void change_expansion_search(std::size_t n) noexcept { typed_->change_expansion_search(n); }
 
     member_citerator_t cbegin() const noexcept { return typed_->cbegin(); }
     member_citerator_t cend() const noexcept { return typed_->cend(); }
@@ -473,6 +475,10 @@ class punned_gt {
     void load(char const* path) { typed_->load(path); }
     void view(char const* path) { typed_->view(path); }
     void reserve(std::size_t capacity) { typed_->reserve(capacity); }
+
+    std::size_t memory_usage(std::size_t allocator_entry_bytes = default_allocator_entry_bytes()) const noexcept {
+        return typed_->memory_usage(allocator_entry_bytes);
+    }
 
     // clang-format off
     add_result_t add(label_t label, f8_bits_t const* vector) { return add_(label, vector, casts_.from_f8); }

--- a/src/test.cpp
+++ b/src/test.cpp
@@ -65,6 +65,9 @@ template <typename scalar_at, typename index_at> void test3d(index_at&& index) {
     assert(matched_count == 3);
     assert(matched_labels[0] == 42);
     assert(std::abs(matched_distances[0]) < 0.01);
+
+    assert(index.memory_usage() > 0);
+    assert(index.stats().max_edges > 0);
 }
 
 int main(int, char**) {


### PR DESCRIPTION
The [`ann-benchmarks`](https://github.com/erikbern/ann-benchmark) has an endpoint to estimate memory-usage of some algorithm implementation. To support that natively, instead of system calls, we add a `memory_usage()` method in C++ and a `memory_usage` computed property to Python. For similar reasons, the `expansion_add` and `expansion_search` are added as mutable computed properties.