### PR TITLE
Fix: Use of `require('usearch')` in node

### DIFF
--- a/javascript/usearch.js
+++ b/javascript/usearch.js
@@ -1,0 +1,3 @@
+const usearch = require('bindings')('usearch');
+
+module.exports = usearch;

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "description": "Smaller & Faster Single-File Vector Search Engine from Unum",
     "author": "Ashot Vardanian",
     "license": "Apache 2.0",
+    "main": "javascript/usearch.js",
     "repository": {
         "type": "git",
         "url": "https://github.com/unum-cloud/usearch.git"


### PR DESCRIPTION
A custom wrapper `usearch.js` was created to load and bind the native module, and it is exported using `module.exports`. The `package.json` file was updated to set `"main": "javascript/usearch.js"`, making `usearch.js` as the main entry point for the module.