### PR TITLE
Add compile time feature-gate for lookups and removals

### DIFF
--- a/c/lib.cpp
+++ b/c/lib.cpp
@@ -59,6 +59,7 @@ add_result_t add_(index_t* index, usearch_label_t label, void const* vector, sca
     }
 }
 
+#if USEARCH_LOOKUP_LABEL
 bool get_(index_t* index, label_t label, void* vector, scalar_kind_t kind) {
     switch (kind) {
     case scalar_kind_t::f32_k: return index->get(label, (f32_t*)vector);
@@ -69,6 +70,7 @@ bool get_(index_t* index, label_t label, void* vector, scalar_kind_t kind) {
     default: return index->empty_search_result().failed("Unknown scalar kind!");
     }
 }
+#endif
 
 search_result_t search_(index_t* index, void const* vector, scalar_kind_t kind, size_t n) {
     switch (kind) {
@@ -153,7 +155,7 @@ USEARCH_EXPORT void usearch_reserve(usearch_index_t index, size_t capacity, usea
     reinterpret_cast<index_t*>(index)->reserve(capacity);
 }
 
-USEARCH_EXPORT void usearch_add(                                                                          //
+USEARCH_EXPORT void usearch_add(                                                                  //
     usearch_index_t index, usearch_label_t label, void const* vector, usearch_scalar_kind_t kind, //
     usearch_error_t* error) {
     add_result_t result = add_(reinterpret_cast<index_t*>(index), label, vector, to_native_scalar(kind));
@@ -161,11 +163,13 @@ USEARCH_EXPORT void usearch_add(                                                
         *error = result.error.what();
 }
 
+#if USEARCH_LOOKUP_LABEL
 USEARCH_EXPORT bool usearch_contains(usearch_index_t index, usearch_label_t label, usearch_error_t*) {
     return reinterpret_cast<index_t*>(index)->contains(label);
 }
+#endif
 
-USEARCH_EXPORT size_t usearch_search(                                                                    //
+USEARCH_EXPORT size_t usearch_search(                                                            //
     usearch_index_t index, void const* vector, usearch_scalar_kind_t kind, size_t results_limit, //
     usearch_label_t* found_labels, usearch_distance_t* found_distances, usearch_error_t* error) {
     search_result_t result = search_(reinterpret_cast<index_t*>(index), vector, to_native_scalar(kind), results_limit);
@@ -177,11 +181,13 @@ USEARCH_EXPORT size_t usearch_search(                                           
     return result.dump_to(found_labels, found_distances);
 }
 
-USEARCH_EXPORT bool usearch_get(                          //
+#if USEARCH_LOOKUP_LABEL
+USEARCH_EXPORT bool usearch_get(                  //
     usearch_index_t index, usearch_label_t label, //
     void* vector, usearch_scalar_kind_t kind, usearch_error_t*) {
     return get_(reinterpret_cast<index_t*>(index), label, vector, to_native_scalar(kind));
 }
+#endif
 
 USEARCH_EXPORT void usearch_remove(usearch_index_t, usearch_label_t, usearch_error_t* error) {
     if (error != nullptr)

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -3,6 +3,7 @@ cmake_minimum_required(VERSION 3.1)
 option(USEARCH_USE_OPENMP "Use OpenMP for a thread pool" OFF)
 option(USEARCH_USE_SIMSIMD "Use SimSIMD hardware-accelerated metrics" OFF)
 option(USEARCH_USE_JEMALLOC "Use JeMalloc for faster memory allocations" OFF)
+option(USEARCH_LOOKUP_LABEL "Compile with label lookup and removal tests" OFF)
 
 # Make "Release" by default
 if(NOT CMAKE_BUILD_TYPE)
@@ -83,6 +84,9 @@ if(${USEARCH_BUILD_TEST})
     target_link_libraries(test PRIVATE Threads::Threads)
     target_include_directories(test PRIVATE ${USEARCH_PUNNED_INCLUDE_DIRS})
     set_target_properties(test PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
+    if (${USEARCH_LOOKUP_LABEL})
+        target_compile_definitions(test PRIVATE USEARCH_LOOKUP_LABEL=1)
+    endif()
 
     if(${CMAKE_VERSION} VERSION_EQUAL 3.13 OR ${CMAKE_VERSION} VERSION_GREATER 3.13)
         include(CTest)

--- a/cpp/test.cpp
+++ b/cpp/test.cpp
@@ -92,16 +92,20 @@ template <typename scalar_at, typename index_at> void test3d_punned(index_at&& i
     index.add(42, view_t{&vec42[0], 3ul});
 
     // Reconstruct
+#if USEARCH_LOOKUP_LABEL
     scalar_t vec42_reconstructed[3] = {0, 0, 0};
     index.get(42, span_t{&vec42_reconstructed[0], 3ul});
     expect(vec42_reconstructed[0] == vec42[0]);
     expect(vec42_reconstructed[1] == vec42[1]);
     expect(vec42_reconstructed[2] == vec42[2]);
+#endif
 
     index.add(43, view_t{&vec43[0], 3ul});
     expect(index.size() == 2);
+#if USEARCH_LOOKUP_LABEL
     index.remove(43);
     expect(index.size() == 1);
+#endif
 }
 
 template <typename index_at> void test_sets(index_at&& index) {


### PR DESCRIPTION
I am not sure you guys want this in upstream usearch. But, we use this for the following:

For our use-case, we only need vector insertions and search.
Currently, usearch **always** builds a lookup table for vector labels at index creation time (e.g. [here](https://github.com/unum-cloud/usearch/blob/main/include/usearch/index_punned_dense.hpp#L405-L406)) to support `contains, get, remove` queries. I think there are many use-cases that do not need these (including our use-case) so it would be good to not pay the cpu and memory cost of this lookup table creation.

This PR feature-gates the index creation functions and all the methods depending on them so one can easily disable them and remove their runtime cost.

Perhaps the one-time lookup table creation cost and the small maintenance cost is trivial for most use-cases. But, for our case, we need to re-initialize the usearch context for each search query so it is crucial to minimize its memory footprint. This is likely not the typical case for usearch, but this is one case to consider.

I considered leaving the code in and just adding a runtime flag to enable lookups. But preferred this approach because with this the compiler and the IDE did more to help ensure available APIs are used.
