### PR TITLE
Improve: Index finalizer method

### DIFF
--- a/python/usearch/index.py
+++ b/python/usearch/index.py
@@ -829,6 +829,9 @@ class Index:
         """
         return self._compiled.level_stats(level)
 
+    def __del__(self):
+        self.reset()
+
     def __repr__(self) -> str:
         f = "usearch.Index({} x {}, {}, expansion: {} & {}, {} vectors in {} levels)"
         return f.format(


### PR DESCRIPTION
Implementing the `__del__` method allows to add custom freeing logic to the object when it is finalized.

From [python docs](https://docs.python.org/3/reference/datamodel.html#object.__del__)
> `object.__del__(self)`
> Called when the instance is about to be destroyed. This is also called a finalizer or (improperly) a destructor. 
> `x.__del__()` ... is only called when x’s reference count reaches zero. 