### PR TITLE
Remove error-causing annotation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ index = Index(
 
 vector = np.array([0.2, 0.6, 0.4])
 index.add(42, vector)
-matches: Matches = index.search(vector, 10)
+matches = index.search(vector, 10)
 
 assert len(index) == 1
 assert len(matches) == 1


### PR DESCRIPTION
This symbol is not imported so this broke the example code.

I got this error:

```pycon
>>> matches: Matches = index.search(vector, 10)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
NameError: name 'Matches' is not defined. Did you mean: 'matches'?
```