### PR TITLE
Build: Fix csharp version update in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -591,8 +591,10 @@ jobs:
       GITHUB_PACKAGES_SOURCE: https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: 'main'  
       - run: git submodule update --init --recursive
-        
+          
       - name: Download usearch libs artifact
         uses: actions/download-artifact@v3
         with:
@@ -606,8 +608,7 @@ jobs:
 
       - name: Pack project
         run: |
-          VERSION_CONTENT=$(< VERSION)
-          dotnet pack "${{ env.SOLUTION }}" -c Release -p:Version="$VERSION_CONTENT" --output ${{ env.NUGET_PACKAGES }}
+          dotnet pack "${{ env.SOLUTION }}" -c Release --output ${{ env.NUGET_PACKAGES }}
         working-directory: ${{ github.workspace }}
 
       - name: Publish to NuGet


### PR DESCRIPTION
This PR addresses the issue of using an outdated version in the C# release CI job by implementing the changes outlined below.

### Before:
- The `actions/checkout@v3` action was set to use the default branch that triggered the workflow. I believe this was the root cause of the issue, as this branch (`main-dev`) had an outdated VERSION file.
- Version information was manually extracted from the VERSION file.

### After:
- Specified the `main` branch for `actions/checkout@v3` to ensure the use of project files updated by semantic-release.
- The CI job now relies on the updated version in `nuget-package.props`, which is set by `update_version.sh`. Manual extraction from the VERSION file has been eliminated.
