### PR TITLE
Fix: Exact search accuracy and speed

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -145,6 +145,7 @@
         "SLOC",
         "sorensen",
         "tanimoto",
+        "tqdm",
         "uninitialize",
         "unumusearch",
         "usearch",

--- a/include/usearch/index_plugins.hpp
+++ b/include/usearch/index_plugins.hpp
@@ -1602,7 +1602,7 @@ class flat_hash_multi_set_gt {
         auto slot_pointer = bucket_pointer + sizeof(bucket_header_t) + sizeof(element_t) * in_bucket_index;
         return {
             *reinterpret_cast<bucket_header_t*>(bucket_pointer),
-            std::uint64_t(1ull) << in_bucket_index,
+            static_cast<std::uint64_t>(1ull) << in_bucket_index,
             *reinterpret_cast<element_t*>(slot_pointer),
         };
     }

--- a/python/scripts/bench_exact.py
+++ b/python/scripts/bench_exact.py
@@ -1,0 +1,44 @@
+from time import time
+
+from usearch.index import search, MetricKind, ScalarKind
+from usearch.compiled import hardware_acceleration
+from faiss import IndexFlatL2, knn
+import numpy as np
+import fire
+
+
+def run(
+    n: int = 10**5,
+    q: int = 10,
+    k: int = 100,
+    ndim: int = 256,
+    half: bool = False,
+):
+    usearch_dtype = ScalarKind.F16 if half else ScalarKind.F32
+    acceleration = hardware_acceleration(
+        dtype=usearch_dtype,
+        ndim=ndim,
+        metric_kind=MetricKind.L2sq,
+    )
+    print("Hardware acceleration in USearch: ", acceleration)
+
+    x = np.random.random((n, ndim))
+    x = x.astype(np.float16) if half else x.astype(np.float32)
+
+    start = time()
+    _ = search(
+        x,
+        x[:q],
+        k,
+        MetricKind.L2sq,
+        exact=True,
+    ).keys
+    print("USearch: ", time() - start)
+
+    start = time()
+    _ = knn(x, x[:q], k)[1]
+    print("FAISS:   ", time() - start)
+
+
+if __name__ == "__main__":
+    fire.Fire(run)

--- a/python/scripts/test_tooling.py
+++ b/python/scripts/test_tooling.py
@@ -11,7 +11,7 @@ from usearch.index import Match, Matches, BatchMatches, Index, Indexes
 
 
 dimensions = [3, 97, 256]
-batch_sizes = [1, 77]
+batch_sizes = [1, 77, 100]
 
 
 @pytest.mark.parametrize("rows", batch_sizes)
@@ -56,15 +56,16 @@ def test_exact_search(rows: int, cols: int):
     :param int cols: The number of columns in the matrix.
     """
     original = np.random.rand(rows, cols)
+    keys = np.arange(rows)
     matches: BatchMatches = search(original, original, min(10, rows), exact=True)
     top_matches = (
         [int(m.keys[0]) for m in matches] if rows > 1 else int(matches.keys[0])
     )
-    assert np.all(top_matches == np.arange(rows))
+    assert np.all(top_matches == keys)
 
-    matches: Matches = search(original, original[0], min(10, rows), exact=True)
+    matches: Matches = search(original, original[-1], min(10, rows), exact=True)
     top_match = int(matches.keys[0])
-    assert top_match == 0
+    assert top_match == keys[-1]
 
 
 def test_matches_creation_and_methods():

--- a/python/usearch/index.py
+++ b/python/usearch/index.py
@@ -180,7 +180,7 @@ def _search_in_compiled(
         vectors = vectors.reshape(1, len(vectors))
     count_vectors = vectors.shape[0]
 
-    def distil_batch(
+    def distill_batch(
         batch_matches: BatchMatches,
     ) -> Union[BatchMatches, Matches]:
         return batch_matches[0] if count_vectors == 1 else batch_matches
@@ -188,22 +188,22 @@ def _search_in_compiled(
     # Create progress bar if needed
     if log:
         name = log if isinstance(log, str) else "Search"
-        pbar = tqdm(
+        progress_bar = tqdm(
             desc=name,
             total=count_vectors,
             unit="vector",
         )
 
         def update_progress_bar(processed: int, total: int) -> bool:
-            pbar.update(processed - pbar.n)
+            progress_bar.update(processed - progress_bar.n)
             return progress if progress else True
 
         tuple_ = compiled_callable(vectors, progress=update_progress_bar, **kwargs)
-        pbar.close()
+        progress_bar.close()
     else:
         tuple_ = compiled_callable(vectors, **kwargs)
 
-    return distil_batch(BatchMatches(*tuple_))
+    return distill_batch(BatchMatches(*tuple_))
 
 
 def _add_to_compiled(


### PR DESCRIPTION
I've fixed the problem spotted by @ebursztein and added an exact search benchmark for small-scale exact search, standard in LLM apps.

```sh
$ python python/scripts/bench_exact.py --ndim 256 --n 100_000 --q 10 --k 100
Hardware acceleration in USearch:  auto
USearch:  0.013957023620605469
FAISS:    0.04720497131347656

$ python python/scripts/bench_exact.py --ndim 256 --n 100_000 --q 10 --k 100 --half
Hardware acceleration in USearch:  auto
USearch:  0.014386892318725586
FAISS:    0.08691692352294922
```

Even without hardware acceleration from SimSIMD, on the M2 Mac Book Pro:

- USearch performs 3.3x faster than FAISS on single-precision vectors.
- USearch performs 6.1x faster than FAISS on single-precision vectors.

---

The script is located at `python/scripts/bench_exact.py` and has a few CLI parameters:

- `--ndim` - number of vector dimensions.
- `--n` - number of vectors in the dataset to search.
- `--q` - number of vectors to query among `n`.
- `--k` - number of closest neighbors to retrieve per query.
- `--half` - use half-precision.

For large `q` FAISS works quite well - in such cases it redirects the query to the linked BLAS implementation. But it means it supports only two metrics - L2 and inner product. With USearch exact search you can still use all the same metrics as with `usearch.index.Index` class and provide custom JIT-ed `CompiledMetric`.