### PR TITLE
test: usearch-js expected results

### DIFF
--- a/javascript/usearch.test.js
+++ b/javascript/usearch.test.js
@@ -36,6 +36,21 @@ test('Batch operations', () => {
     assert.deepEqual(results.distances, new Float32Array([45, 130]), 'distances should be 45 and 130');
 });
 
+test("Expected results", () => {
+    var index = new usearch.Index({
+        metric: "cos",
+        connectivity: 16,
+        dimensions: 3,
+    });
+    index.add(42n, new Float32Array([0.2, 0.6, 0.4]));
+    var results = index.search(new Float32Array([0.2, 0.6, 0.4]), 10);
+
+    assert.equal(index.size(), 1);
+    assert.deepEqual(results.keys, new BigUint64Array([42n]));
+    assert.deepEqual(results.distances, new Float32Array([0]));
+});
+
+
 
 test('Operations with invalid values', () => {
     const indexBatch = new usearch.Index(2, 'l2sq');


### PR DESCRIPTION
Test example code

The `BigUint64Array` and `Float32Array` have a length of 10, not 1

```
  AssertionError [ERR_ASSERTION]: Expected values to be loosely deep-equal:

  BigUint64Array(10) [
    42n,
    0n,
    0n,
    0n,
    0n,
    0n,
    0n,
    0n,
    0n,
    0n
  ]

  should loosely deep-equal

  BigUint64Array(1) [
    42n
  ]
      at TestContext.<anonymous> (/Users/jlarmst/Desktop/typefoundriesdirect/usearch/javascript/usearch.test.js:46:10)
      at Test.runInAsyncScope (node:async_hooks:203:9)
      at Test.run (node:internal/test_runner/test:573:25)
      at Test.processPendingSubtests (node:internal/test_runner/test:318:18)
      at Test.postRun (node:internal/test_runner/test:642:19)
      at Test.run (node:internal/test_runner/test:601:10)
      at async startSubtest (node:internal/test_runner/harness:202:3) {
    generatedMessage: true,
    code: 'ERR_ASSERTION',
    actual: BigUint64Array(10) [
      42n, 0n, 0n, 0n, 0n,
       0n, 0n, 0n, 0n, 0n
    ],
    expected: BigUint64Array(1) [ 42n ],
    operator: 'deepEqual'
  }
```