### PR TITLE
Fix: undefined var error in `remove` api

### DIFF
--- a/javascript/usearch.js
+++ b/javascript/usearch.js
@@ -303,7 +303,7 @@ class Index {
      */
     remove(keys) {
         let normalizedKeys = normalizeKeys(keys);
-        normalizedResults = this._compiledIndex.remove(normalizedKeys);
+        let normalizedResults = this._compiledIndex.remove(normalizedKeys);
         if (isOneKey(keys))
             return normalizedResults[0];
         else


### PR DESCRIPTION
Just a quick fix for error encountered when using usearch@2.8.14