### PR TITLE
Add libpthread for older linux gcc builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -186,9 +186,7 @@ function (setup_target TARGET_NAME)
             target_link_libraries(${TARGET_NAME} PRIVATE OpenMP::OpenMP_CXX)
         endif ()
 
-        if (CMAKE_HOST_SYSTEM_NAME MATCHES "Darwin")
-            target_link_libraries(${TARGET_NAME} PRIVATE Threads::Threads)
-        endif ()
+        target_link_libraries(${TARGET_NAME} PRIVATE Threads::Threads)
 
     elseif (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
         target_compile_options(

--- a/include/usearch/index.hpp
+++ b/include/usearch/index.hpp
@@ -3362,7 +3362,7 @@ class index_gt {
         visits.clear();
 
         // Optional prefetching
-        if (!std::is_same<typename std::decay<prefetch_at>::type, dummy_prefetch_t>::value)
+        if (!is_dummy<prefetch_at>())
             prefetch(citerator_at(closest_slot), citerator_at(closest_slot + 1));
 
         distance_t closest_dist = context.measure(query, citerator_at(closest_slot), metric);
@@ -3374,7 +3374,7 @@ class index_gt {
                 neighbors_ref_t closest_neighbors = neighbors_non_base_(node_at_(closest_slot), level);
 
                 // Optional prefetching
-                if (!std::is_same<typename std::decay<prefetch_at>::type, dummy_prefetch_t>::value) {
+                if (!is_dummy<prefetch_at>()) {
                     candidates_range_t missing_candidates{*this, closest_neighbors, visits};
                     prefetch(missing_candidates.begin(), missing_candidates.end());
                 }
@@ -3416,7 +3416,7 @@ class index_gt {
             return false;
 
         // Optional prefetching
-        if (!std::is_same<typename std::decay<prefetch_at>::type, dummy_prefetch_t>::value)
+        if (!is_dummy<prefetch_at>())
             prefetch(citerator_at(start_slot), citerator_at(start_slot + 1));
 
         distance_t radius = context.measure(query, citerator_at(start_slot), metric);
@@ -3441,7 +3441,7 @@ class index_gt {
             neighbors_ref_t candidate_neighbors = neighbors_(candidate_ref, level);
 
             // Optional prefetching
-            if (!std::is_same<typename std::decay<prefetch_at>::type, dummy_prefetch_t>::value) {
+            if (!is_dummy<prefetch_at>()) {
                 candidates_range_t missing_candidates{*this, candidate_neighbors, visits};
                 prefetch(missing_candidates.begin(), missing_candidates.end());
             }
@@ -3490,7 +3490,7 @@ class index_gt {
             return false;
 
         // Optional prefetching
-        if (!std::is_same<typename std::decay<prefetch_at>::type, dummy_prefetch_t>::value)
+        if (!is_dummy<prefetch_at>())
             prefetch(citerator_at(start_slot), citerator_at(start_slot + 1));
 
         distance_t radius = context.measure(query, citerator_at(start_slot), metric);
@@ -3510,7 +3510,7 @@ class index_gt {
             neighbors_ref_t candidate_neighbors = neighbors_base_(node_at_(candidate.slot));
 
             // Optional prefetching
-            if (!std::is_same<typename std::decay<prefetch_at>::type, dummy_prefetch_t>::value) {
+            if (!is_dummy<prefetch_at>()) {
                 candidates_range_t missing_candidates{*this, candidate_neighbors, visits};
                 prefetch(missing_candidates.begin(), missing_candidates.end());
             }


### PR DESCRIPTION
Latest versions of libc (>= 2.34, released on August, 2021) have
libpthread built in but in slightly older libcs one has to still
specify -llibpthread to explicitly link it in
The commit makes sure usearch compiles successfully with these
older libcs

It changes nothing on newer libcs as libpthread exists on newer libcs as an empty library