### PR TITLE
Fix some miscelenious issues encountered while working on #335

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,11 @@ if (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
     set(USEARCH_IS_MAIN_PROJECT ON)
 endif ()
 
+# Allow CMake 3.13+ to override options when using FetchContent / add_subdirectory
+if (POLICY CMP0077)
+    cmake_policy(SET CMP0077 NEW)
+endif ()
+
 # Options
 option(USEARCH_INSTALL "Install CMake targets" OFF)
 
@@ -30,11 +35,6 @@ option(USEARCH_BUILD_WOLFRAM "Compile Wolfram Language bindings" OFF)
 # Includes
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake ${CMAKE_MODULE_PATH})
 include(ExternalProject)
-
-# Allow CMake 3.13+ to override options when using FetchContent / add_subdirectory
-if (POLICY CMP0077)
-    cmake_policy(SET CMP0077 NEW)
-endif ()
 
 # Configuration
 include(GNUInstallDirs)

--- a/cpp/test.cpp
+++ b/cpp/test.cpp
@@ -209,7 +209,14 @@ void test_cosine(std::size_t collection_size, std::size_t dimensions) {
             metric_punned_t metric(dimensions, metric_kind_t::cos_k, scalar_kind<scalar_at>());
             index_dense_config_t config(connectivity);
             config.multi = multi;
-            index_t index = index_t::make(metric, config);
+            index_t index;
+            {
+                index_t index_tmp1 = index_t::make(metric, config);
+                // move construction
+                index_t index_tmp2 = std::move(index_tmp1);
+                // move assignment
+                index = std::move(index_tmp2);
+            }
             test_cosine<true>(index, matrix);
         }
     }

--- a/include/usearch/index.hpp
+++ b/include/usearch/index.hpp
@@ -1362,7 +1362,7 @@ class output_file_t {
     serialization_result_t write(void const* begin, std::size_t length) noexcept {
         serialization_result_t result;
         std::size_t written = std::fwrite(begin, length, 1, file_);
-        if (!written)
+        if (length && !written)
             return result.failed(std::strerror(errno));
         return result;
     }
@@ -1404,7 +1404,7 @@ class input_file_t {
     serialization_result_t read(void* begin, std::size_t length) noexcept {
         serialization_result_t result;
         std::size_t read = std::fread(begin, length, 1, file_);
-        if (!read)
+        if (length && !read)
             return result.failed(std::feof(file_) ? "End of file reached!" : std::strerror(errno));
         return result;
     }

--- a/include/usearch/index_plugins.hpp
+++ b/include/usearch/index_plugins.hpp
@@ -1819,7 +1819,8 @@ class flat_hash_multi_set_gt {
         }
 
         // Reset populated slots count
-        std::memset(data_, 0, buckets_ * bytes_per_bucket());
+        if (data_)
+            std::memset(data_, 0, buckets_ * bytes_per_bucket());
         populated_slots_ = 0;
     }
 


### PR DESCRIPTION
Fix some miscelenious issues encountered while working on #335

1. [Add move construction tests and fix an issue caused by them](https://github.com/unum-cloud/usearch/commit/78ea641c5d4a41341efb0cf2544e557f7619aa28)
ASAN flagged the memset call on empty buffer when the test ran with the added move construction portion

2. [Only consider zero length IO an error if input buffer was larger than zero](https://github.com/unum-cloud/usearch/commit/aafff91bf52e4e151e0b1487724113d38aa4729a)

5. [Move option-override policy opt-in before policy definitions so overr…](https://github.com/unum-cloud/usearch/commit/3731149c9d7d680181addd2bc283c513a9272b11) 
