### PR TITLE
Support ES module import

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "exports": {
         ".": {
             "types": "./javascript/types/usearch.d.ts",
-            "require": "./javascript/usearch.js"
+            "require": "./javascript/usearch.js",
+            "import": "./javascript/usearch.js"
         },
         "./package.json": "./package.json"
     },


### PR DESCRIPTION
Enables importing like this:

`import * as usearch from 'usearch'`

https://nodejs.org/api/packages.html#conditional-exports

Without this fix I was seeing this error message:

```
Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: No "exports" main defined in .../node_modules/usearch/package.json
```