### PR TITLE
Fix build issues on node

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -495,7 +495,14 @@ jobs:
         if: matrix.os == 'macos-latest'
       - name: Extra for cross build
         if: matrix.os == 'ubuntu-22.04'
-        run: npm run prebuild-arm64
+        run: |
+          export CC=aarch64-linux-gnu-gcc
+          export CXX=aarch64-linux-gnu-g++
+          export AR=aarch64-linux-gnu-ar
+          export AS=aarch64-linux-gnu-as
+          export LD=aarch64-linux-gnu-ld
+          export STRIP=aarch64-linux-gnu-strip
+          npm run prebuild-arm64
       - uses: actions/upload-artifact@v3
         with:
           name: prebuilds

--- a/package.json
+++ b/package.json
@@ -17,7 +17,14 @@
         "node": "~10 >=10.20 || >=12.17"
     },
     "files": [
-        "javascript/dist",
+        "binding.gyp",
+        "c",
+        "cpp",
+        "cmake",
+        "fp16",
+        "simsimd",
+        "include",
+        "javascript",
         "prebuilds"
     ],
     "dependencies": {


### PR DESCRIPTION
This does two things:

1. changes what gets included in npm so that a backup build can proceed. I have tested this in docker linux arm64.

2. adds some info that will hopefully cause prebuildify to correctly cross compile for linux-arm64

Fixes #377 