### PR TITLE
Fix -Wdeprecated-this-capture with GCC 11

### DIFF
--- a/include/usearch/index_dense.hpp
+++ b/include/usearch/index_dense.hpp
@@ -708,7 +708,7 @@ class index_dense_gt {
         cluster_config.thread = lock.thread_id;
         cluster_config.expansion = config_.expansion_search;
         metric_proxy_t metric{*this};
-        auto allow = [=](member_cref_t const& member) noexcept { return member.key != free_key_; };
+        auto allow = [=, this](member_cref_t const& member) noexcept { return member.key != free_key_; };
 
         // Find the closest cluster for any vector under that key.
         while (key_range.first != key_range.second) {
@@ -1787,7 +1787,7 @@ class index_dense_gt {
         search_config.expansion = config_.expansion_search;
         search_config.exact = exact;
 
-        auto allow = [=](member_cref_t const& member) noexcept { return member.key != free_key_; };
+        auto allow = [=, this](member_cref_t const& member) noexcept { return member.key != free_key_; };
         return typed_->search(vector_data, wanted, metric_proxy_t{*this}, search_config, allow);
     }
 
@@ -1810,7 +1810,7 @@ class index_dense_gt {
         cluster_config.thread = lock.thread_id;
         cluster_config.expansion = config_.expansion_search;
 
-        auto allow = [=](member_cref_t const& member) noexcept { return member.key != free_key_; };
+        auto allow = [=, this](member_cref_t const& member) noexcept { return member.key != free_key_; };
         return typed_->cluster(vector_data, level, metric_proxy_t{*this}, cluster_config, allow);
     }
 


### PR DESCRIPTION
Fixing the warnings below:

```
../../src/inline-thirdparty/usearch/usearch/index_dense.hpp: In lambda function:
../../src/inline-thirdparty/usearch/usearch/index_dense.hpp:711:22: error: implicit capture of ‘this’ via ‘[=]’ is deprecated in C++20 [-Werror=deprecated]
  711 |         auto allow = [=](member_cref_t const& member) noexcept { return member.key != free_key_; };
      |                      ^
../../src/inline-thirdparty/usearch/usearch/index_dense.hpp:711:22: note: add explicit ‘this’ or ‘*this’ capture
../../src/inline-thirdparty/usearch/usearch/index_dense.hpp: In lambda function:
../../src/inline-thirdparty/usearch/usearch/index_dense.hpp:1790:22: error: implicit capture of ‘this’ via ‘[=]’ is deprecated in C++20 [-Werror=deprecated]
 1790 |         auto allow = [=](member_cref_t const& member) noexcept { return member.key != free_key_; };
      |                      ^
../../src/inline-thirdparty/usearch/usearch/index_dense.hpp:1790:22: note: add explicit ‘this’ or ‘*this’ capture
../../src/inline-thirdparty/usearch/usearch/index_dense.hpp: In lambda function:
../../src/inline-thirdparty/usearch/usearch/index_dense.hpp:1813:22: error: implicit capture of ‘this’ via ‘[=]’ is deprecated in C++20 [-Werror=deprecated]
 1813 |         auto allow = [=](member_cref_t const& member) noexcept { return member.key != free_key_; };
      |                      ^
../../src/inline-thirdparty/usearch/usearch/index_dense.hpp:1813:22: note: add explicit ‘this’ or ‘*this’ capture
cc1plus: all warnings being treated as errors
```