### PR TITLE
Add Swift test to illustrate issue #399

### DIFF
--- a/swift/Test.swift
+++ b/swift/Test.swift
@@ -39,4 +39,34 @@ class Test: XCTestCase {
         index.remove(key: 49)
         assert(index.count(key: 49) == 0)
     }
+
+    func testIssue399() {
+        let index = USearchIndex.make(
+            metric: USearchMetric.l2sq,
+            dimensions: 1,
+            connectivity: 8,
+            quantization: USearchScalar.F32
+        )
+        index.reserve(3)
+
+        // add 3 entries then ensure all 3 are returned
+        index.add(key: 1, vector: [1.1])
+        index.add(key: 2, vector: [2.1])
+        index.add(key: 3, vector: [3.1])
+        XCTAssertEqual(index.count, 3)
+        XCTAssertEqual(index.search(vector: [1.0], count: 3).0, [1, 2, 3]) // works 😎
+
+        // replace second-added entry then ensure all 3 are still returned
+        index.remove(key: 2)
+        index.add(key: 2, vector: [2.2])
+        XCTAssertEqual(index.count, 3)
+        XCTAssertEqual(index.search(vector: [1.0], count: 3).0, [1, 2, 3]) // works 😎
+
+        // replace first-added entry then ensure all 3 are still returned
+        index.remove(key: 1)
+        index.add(key: 1, vector: [1.2])
+        let afterReplacingInitial = index.search(vector: [1.0], count: 3).0
+        XCTAssertEqual(index.count, 3)
+        XCTAssertEqual(afterReplacingInitial, [1, 2, 3]) // v2.11.7 fails with "[1] != [1, 2, 3]" 😨
+    }
 }


### PR DESCRIPTION
Add a swift test to demonstrate an issue where replacing the initially-added item in an index makes all subsequently added items no longer visible in `search` results. See issue #399 for more details.