### PR TITLE
Fix uint32_t to uint40_t construction and cast

### DIFF
--- a/include/usearch/index.hpp
+++ b/include/usearch/index.hpp
@@ -785,7 +785,7 @@ class usearch_pack_m uint40_t {
 
   public:
     inline uint40_t() noexcept { broadcast(0); }
-    inline uint40_t(std::uint32_t n) noexcept { std::memcpy(&octets[1], &n, 4); }
+    inline uint40_t(std::uint32_t n) noexcept { std::memcpy(&octets, &n, 4); }
 
 #ifdef USEARCH_64BIT_ENV
     inline uint40_t(std::uint64_t n) noexcept { std::memcpy(octets, &n, 5); }
@@ -811,7 +811,7 @@ class usearch_pack_m uint40_t {
 #ifdef USEARCH_64BIT_ENV
         std::memcpy(&result, octets, 5);
 #else
-        std::memcpy(&result, octets + 1, 4);
+        std::memcpy(&result, octets, 4);
 #endif
         return result;
     }


### PR DESCRIPTION
Found with a test case in lantern.

Quick example:
```
uint32_t n32 = 42;
uint64_t n64 = 42;
uint40_t n40_from_32(n32);
uint40_t n40_from_64(n64);
std::cerr << "n40_from_32: " << std::to_string(n40_from_32) << 
                    " n40_from_64: " << std::to_string(n40_from_64)  << "\n";
```

This was printing "n40_from_32: 10752 n40_from_64: 42".
After the patch, it prints "n40_from_32: 42 n40_from_64: 42"
