### PR TITLE
Add -march=native in clang compile flags to enable auto-vectorization

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -201,6 +201,8 @@ function (setup_target TARGET_NAME)
                     -fPIC
                     -pedantic
                     -Wfatal-errors
+                    -march=native
+                    -ftree-vectorize
                     # Don't complain if the for-loops were not vectorzied
                     -Wpass-failed=transform-warning
                     -fcolor-diagnostics


### PR DESCRIPTION
Tested on Macbook Pro with 2.4 GHz Intel Core i9, Clang 15

`grep` output of objdump on bench_cpp when these flags are present:

```
postgres@4832feb5168c:/lantern_shared/third_party/usearch/build_release$
objdump -d ./bench_cpp | grep vzero | head
       1cad3:       c5 f8 77                vzeroupper
       1cb1e:       c5 f8 77                vzeroupper
       ...
```

grep output is empty when the flags are not present