### PR TITLE
Extend java API with vector access

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -86,6 +86,7 @@ model {
     }
 
     toolChains {
+        clang(Clang)
         gcc(Gcc) {
             target("linux_aarch64") {
                 cppCompiler.withArguments { args ->

--- a/java/cloud/unum/usearch/Index.java
+++ b/java/cloud/unum/usearch/Index.java
@@ -123,6 +123,17 @@ public class Index {
   }
 
   /**
+   * Return the contents of the vector at key.
+   * 
+   * @param key key to lookup.
+   * @return the contents of the vector.
+   * @throws {@link IllegalArgumentException} is key is not available.
+   */
+  public float[] get(int key) {
+    return c_get(c_ptr, key);
+  }
+
+  /**
    * Saves the index to a file.
    *
    * @param path the file path where the index will be saved.
@@ -342,6 +353,8 @@ public class Index {
   private static native void c_add(long ptr, int key, float vector[]);
 
   private static native int[] c_search(long ptr, float vector[], long count);
+
+  private static native float[] c_get(long ptr, int key);
 
   private static native void c_save(long ptr, String path);
 

--- a/java/cloud/unum/usearch/Index.java
+++ b/java/cloud/unum/usearch/Index.java
@@ -296,7 +296,11 @@ public class Index {
       System.loadLibrary("usearch"); // used for tests. This library in classpath only
     } catch (UnsatisfiedLinkError e) {
       try {
-        NativeUtils.loadLibraryFromJar("/usearch/libusearch.so");
+        if (System.getProperty("os.name").equals("Mac OS X")) {
+          NativeUtils.loadLibraryFromJar("/usearch/libusearch.dylib");
+        } else {
+          NativeUtils.loadLibraryFromJar("/usearch/libusearch.so");
+        }
       } catch (IOException e1) {
         throw new RuntimeException(e1);
       }

--- a/java/cloud/unum/usearch/cloud_unum_usearch_Index.cpp
+++ b/java/cloud/unum/usearch/cloud_unum_usearch_Index.cpp
@@ -141,6 +141,26 @@ JNIEXPORT void JNICALL Java_cloud_unum_usearch_Index_c_1add( //
     (*env).ReleaseFloatArrayElements(vector, vector_data, 0);
 }
 
+JNIEXPORT jfloatArray JNICALL Java_cloud_unum_usearch_Index_c_1get(
+    JNIEnv *env, jclass, jlong c_ptr, jint key) {
+    
+    auto index = reinterpret_cast<index_dense_t*>(c_ptr);
+    size_t dim = index->dimensions();
+    std::unique_ptr<jfloat[]> vector(new jfloat[dim]);
+    if (index->get(key, vector.get()) == 0) {
+        jclass jc = env->FindClass("java/lang/IllegalArgumentException");
+        if (jc) {
+            env->ThrowNew(jc, "key not found");
+        }
+    }
+    jfloatArray jvector = env->NewFloatArray(dim);
+    if (jvector == nullptr) {  // out of memory
+        return nullptr;
+    }
+    env->SetFloatArrayRegion(jvector, 0, dim, vector.get());
+    return jvector;
+}
+
 JNIEXPORT jintArray JNICALL Java_cloud_unum_usearch_Index_c_1search( //
     JNIEnv* env, jclass, jlong c_ptr, jfloatArray vector, jlong wanted) {
 

--- a/java/cloud/unum/usearch/cloud_unum_usearch_Index.h
+++ b/java/cloud/unum/usearch/cloud_unum_usearch_Index.h
@@ -73,6 +73,14 @@ JNIEXPORT void JNICALL Java_cloud_unum_usearch_Index_c_1add
 
 /*
  * Class:     cloud_unum_usearch_Index
+ * Method:    c_get
+ * Signature: (JI)[F
+ */
+JNIEXPORT jfloatArray JNICALL Java_cloud_unum_usearch_Index_c_1get
+  (JNIEnv *, jclass, jlong, jint);
+
+/*
+ * Class:     cloud_unum_usearch_Index
  * Method:    c_search
  * Signature: (J[FJ)[I
  */

--- a/java/test/IndexTest.java
+++ b/java/test/IndexTest.java
@@ -1,5 +1,7 @@
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertThrows;
+
 import java.io.File;
-import java.util.Arrays;
 
 import org.junit.Test;
 
@@ -27,5 +29,23 @@ public class IndexTest {
         int[] keys = index.search(vec, 5);
 
         System.out.println("Java Tests Passed!");
+    }
+
+    public void testGetSuccess() {
+        Index index = new Index.Config().metric("cos").dimensions(2).build();
+        float vec[] = { 10, 20 };
+        index.reserve(10);
+        index.add(42, vec);
+
+        assertArrayEquals(vec, index.get(42), 0.01f);
+    }
+
+    public void testGetFailed() {
+        Index index = new Index.Config().metric("cos").dimensions(2).build();
+        float vec[] = { 10, 20 };
+        index.reserve(10);
+        index.add(42, vec);
+
+        assertThrows(IllegalArgumentException.class, () -> index.get(41));
     }
 }


### PR DESCRIPTION
Add `Index.get(int key)` method that returns the contents of the vector on the java heap. This method will throw an
`IllegalArgumentException` if key is not found in the index.