### PR TITLE
Java: Free resources via `AutoCloseable.close()`

### DIFF
--- a/java/cloud/unum/usearch/Index.java
+++ b/java/cloud/unum/usearch/Index.java
@@ -19,7 +19,7 @@ import java.io.IOException;
  *      "https://www3.ntu.edu.sg/home/ehchua/programming/java/javanativeinterface.html">Java
  *      Native Interface tutorial</a>
  */
-public class Index {
+public class Index implements AutoCloseable {
 
   private long c_ptr = 0;
 
@@ -56,12 +56,24 @@ public class Index {
         expansion_search);
   }
 
+  @Override
+  public void close() {
+    if (c_ptr == 0) {
+      throw new IllegalStateException("Index already closed");
+    }
+    c_destroy(c_ptr);
+    c_ptr = 0;
+  }
+
   /**
    * Retrieves the current size of the index.
    *
    * @return the number of vectors currently indexed.
    */
   public long size() {
+    if (c_ptr == 0) {
+      throw new IllegalStateException("Index already closed");
+    }
     return c_size(c_ptr);
   }
 
@@ -71,6 +83,9 @@ public class Index {
    * @return the connectivity parameter that limits connections-per-node in graph.
    */
   public long connectivity() {
+    if (c_ptr == 0) {
+      throw new IllegalStateException("Index already closed");
+    }
     return c_connectivity(c_ptr);
   }
 
@@ -80,6 +95,9 @@ public class Index {
    * @return the number of dimensions in the vectors.
    */
   public long dimensions() {
+    if (c_ptr == 0) {
+      throw new IllegalStateException("Index already closed");
+    }
     return c_dimensions(c_ptr);
   }
 
@@ -89,6 +107,9 @@ public class Index {
    * @return the total capacity including current size.
    */
   public long capacity() {
+    if (c_ptr == 0) {
+      throw new IllegalStateException("Index already closed");
+    }
     return c_capacity(c_ptr);
   }
 
@@ -98,6 +119,9 @@ public class Index {
    * @param capacity the desired total capacity including current size.
    */
   public void reserve(long capacity) {
+    if (c_ptr == 0) {
+      throw new IllegalStateException("Index already closed");
+    }
     c_reserve(c_ptr, capacity);
   }
 
@@ -108,6 +132,9 @@ public class Index {
    * @param vector the vector data
    */
   public void add(int key, float vector[]) {
+    if (c_ptr == 0) {
+      throw new IllegalStateException("Index already closed");
+    }
     c_add(c_ptr, key, vector);
   }
 
@@ -119,6 +146,9 @@ public class Index {
    * @return an array of keys of the nearest neighbors
    */
   public int[] search(float vector[], long count) {
+    if (c_ptr == 0) {
+      throw new IllegalStateException("Index already closed");
+    }
     return c_search(c_ptr, vector, count);
   }
 
@@ -130,6 +160,9 @@ public class Index {
    * @throws {@link IllegalArgumentException} is key is not available.
    */
   public float[] get(int key) {
+    if (c_ptr == 0) {
+      throw new IllegalStateException("Index already closed");
+    }
     return c_get(c_ptr, key);
   }
 
@@ -139,6 +172,9 @@ public class Index {
    * @param path the file path where the index will be saved.
    */
   public void save(String path) {
+    if (c_ptr == 0) {
+      throw new IllegalStateException("Index already closed");
+    }
     c_save(c_ptr, path);
   }
 
@@ -148,6 +184,9 @@ public class Index {
    * @param path the file path from where the index will be loaded.
    */
   public void load(String path) {
+    if (c_ptr == 0) {
+      throw new IllegalStateException("Index already closed");
+    }
     c_load(c_ptr, path);
   }
 
@@ -157,6 +196,9 @@ public class Index {
    * @param path the file path from where the view will be created.
    */
   public void view(String path) {
+    if (c_ptr == 0) {
+      throw new IllegalStateException("Index already closed");
+    }
     c_view(c_ptr, path);
   }
 
@@ -168,6 +210,9 @@ public class Index {
    *         otherwise.
    */
   public boolean remove(int key) {
+    if (c_ptr == 0) {
+      throw new IllegalStateException("Index already closed");
+    }
     return c_remove(c_ptr, key);
   }
 
@@ -180,6 +225,9 @@ public class Index {
    *         otherwise.
    */
   public boolean rename(int from, int to) {
+    if (c_ptr == 0) {
+      throw new IllegalStateException("Index already closed");
+    }
     return c_rename(c_ptr, from, to);
   }
 
@@ -324,8 +372,9 @@ public class Index {
    * @param args command line arguments (not used in this case)
    */
   public static void main(String[] args) {
-    Index index = new Index.Config().metric("cos").dimensions(100).build();
-    index.size();
+    try (Index index = new Index.Config().metric("cos").dimensions(100).build()) {
+      index.size();
+    }
     System.out.println("Java tests passed!");
   }
 

--- a/java/test/IndexTest.java
+++ b/java/test/IndexTest.java
@@ -1,4 +1,5 @@
 import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 
 import java.io.File;
@@ -22,30 +23,46 @@ public class IndexTest {
         String path = "./tmp/";
         deleteDirectoryFiles(path);
 
-        Index index = new Index.Config().metric("cos").dimensions(2).build();
-        float vec[] = { 10, 20 };
-        index.reserve(10);
-        index.add(42, vec);
-        int[] keys = index.search(vec, 5);
+        try (Index index = new Index.Config().metric("cos").dimensions(2).build()) {
+            float vec[] = { 10, 20 };
+            index.reserve(10);
+            index.add(42, vec);
+            int[] keys = index.search(vec, 5);
+        }
 
         System.out.println("Java Tests Passed!");
     }
 
+    @Test
     public void testGetSuccess() {
-        Index index = new Index.Config().metric("cos").dimensions(2).build();
-        float vec[] = { 10, 20 };
-        index.reserve(10);
-        index.add(42, vec);
+        try (Index index = new Index.Config().metric("cos").dimensions(2).build()) {
+            float vec[] = { 10, 20 };
+            index.reserve(10);
+            index.add(42, vec);
 
-        assertArrayEquals(vec, index.get(42), 0.01f);
+            assertArrayEquals(vec, index.get(42), 0.01f);
+        }
     }
 
+    @Test
     public void testGetFailed() {
+        try (Index index = new Index.Config().metric("cos").dimensions(2).build()) {
+            float vec[] = { 10, 20 };
+            index.reserve(10);
+            index.add(42, vec);
+
+            assertThrows(IllegalArgumentException.class, () -> index.get(41));
+        }
+    }
+
+    @Test
+    public void testUseAfterClose() {
         Index index = new Index.Config().metric("cos").dimensions(2).build();
         float vec[] = { 10, 20 };
         index.reserve(10);
         index.add(42, vec);
-
-        assertThrows(IllegalArgumentException.class, () -> index.get(41));
+        assertEquals(1, index.size());
+        index.close();
+        assertThrows(IllegalStateException.class, () -> index.size());
     }
 }


### PR DESCRIPTION
Implement `AutoCloseable.close()` to free underlying resources not controlled by the java runtime.

After `close()` all methods will throw an `IllegalStateException` if called to avoid segfaults in JNI.