### PR TITLE
Add java `Index.{load,view}FromPath(String)`

### DIFF
--- a/java/cloud/unum/usearch/Index.java
+++ b/java/cloud/unum/usearch/Index.java
@@ -46,16 +46,33 @@ public class Index implements AutoCloseable {
     long expansion_add,
     long expansion_search
   ) {
-    c_ptr =
-      c_create(
-        metric,
-        quantization,
-        dimensions,
-        capacity,
-        connectivity,
-        expansion_add,
-        expansion_search
-      );
+    this(c_create(metric, quantization, dimensions, capacity, connectivity, expansion_add, expansion_search));
+  }
+
+  private Index(long c_ptr) {
+    this.c_ptr = c_ptr;
+  }
+
+  /**
+   * Loads an index from a file into memory.
+   *
+   * @param path path to load from
+   * @return a mutable Index.
+   * @throws {@Error} if any part of loading from path failed.
+   */
+  public static Index loadFromPath(String path) {
+    return new Index(c_createFromFile(path, false));
+  }
+
+  /**
+   * Loads an index view from a file into memory.
+   *
+   * @param path path to load from
+   * @return an immutable Index.
+   * @throws {@Error} if any part of loading from path failed.
+   */
+  public static Index viewFromPath(String path) {
+    return new Index(c_createFromFile(path, true));
   }
 
   @Override
@@ -391,6 +408,8 @@ public class Index implements AutoCloseable {
     long expansion_add,
     long expansion_search
   );
+
+  private static native long c_createFromFile(String path, boolean view);
 
   private static native void c_destroy(long ptr);
 

--- a/java/cloud/unum/usearch/cloud_unum_usearch_Index.cpp
+++ b/java/cloud/unum/usearch/cloud_unum_usearch_Index.cpp
@@ -60,6 +60,22 @@ cleanup:
     return result;
 }
 
+JNIEXPORT jlong JNICALL Java_cloud_unum_usearch_Index_c_1createFromFile(JNIEnv *env, jclass, jstring path, jboolean view) {
+    char const* path_cstr = env->GetStringUTFChars(path, 0);
+    index_dense_t::state_result_t make_result = index_dense_t::make(path_cstr, view);
+    env->ReleaseStringUTFChars(path, path_cstr);
+    if (!make_result) {
+        jclass jc = env->FindClass("java/lang/Error");
+        if (jc) {
+            env->ThrowNew(jc, make_result.error.release());
+        }
+    }
+    index_dense_t* result_ptr = new index_dense_t(std::move(make_result.index));
+    jlong result;
+    std::memcpy(&result, &result_ptr, sizeof(jlong));
+    return result;
+}
+
 JNIEXPORT void JNICALL Java_cloud_unum_usearch_Index_c_1save(JNIEnv* env, jclass, jlong c_ptr, jstring path) {
     char const* path_cstr = (*env).GetStringUTFChars(path, 0);
     serialization_result_t result = reinterpret_cast<index_dense_t*>(c_ptr)->save(path_cstr);

--- a/java/cloud/unum/usearch/cloud_unum_usearch_Index.h
+++ b/java/cloud/unum/usearch/cloud_unum_usearch_Index.h
@@ -17,6 +17,14 @@ JNIEXPORT jlong JNICALL Java_cloud_unum_usearch_Index_c_1create
 
 /*
  * Class:     cloud_unum_usearch_Index
+ * Method:    c_createFromFile
+ * Signature: (Ljava/lang/String;Z)J
+ */
+JNIEXPORT jlong JNICALL Java_cloud_unum_usearch_Index_c_1createFromFile
+  (JNIEnv *, jclass, jstring, jboolean);
+
+/*
+ * Class:     cloud_unum_usearch_Index
  * Method:    c_destroy
  * Signature: (J)V
  */
@@ -73,19 +81,19 @@ JNIEXPORT void JNICALL Java_cloud_unum_usearch_Index_c_1add
 
 /*
  * Class:     cloud_unum_usearch_Index
- * Method:    c_get
- * Signature: (JI)[F
- */
-JNIEXPORT jfloatArray JNICALL Java_cloud_unum_usearch_Index_c_1get
-  (JNIEnv *, jclass, jlong, jint);
-
-/*
- * Class:     cloud_unum_usearch_Index
  * Method:    c_search
  * Signature: (J[FJ)[I
  */
 JNIEXPORT jintArray JNICALL Java_cloud_unum_usearch_Index_c_1search
   (JNIEnv *, jclass, jlong, jfloatArray, jlong);
+
+/*
+ * Class:     cloud_unum_usearch_Index
+ * Method:    c_get
+ * Signature: (JI)[F
+ */
+JNIEXPORT jfloatArray JNICALL Java_cloud_unum_usearch_Index_c_1get
+  (JNIEnv *, jclass, jlong, jint);
 
 /*
  * Class:     cloud_unum_usearch_Index

--- a/java/test/IndexTest.java
+++ b/java/test/IndexTest.java
@@ -3,6 +3,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 
 import java.io.File;
+import java.io.IOException;
 
 import org.junit.Test;
 
@@ -64,5 +65,21 @@ public class IndexTest {
         assertEquals(1, index.size());
         index.close();
         assertThrows(IllegalStateException.class, () -> index.size());
+    }
+
+    @Test
+    public void testLoadFromPath() throws IOException {
+        File indexFile = File.createTempFile("test", "uidx");
+
+        float vec[] = { 10, 20 };
+        try (Index index = new Index.Config().metric("cos").dimensions(2).build()) {
+            index.reserve(10);
+            index.add(42, vec);
+            index.save(indexFile.getAbsolutePath());
+        }
+
+        try (Index index = Index.loadFromPath(indexFile.getAbsolutePath())) {
+            assertArrayEquals(vec, index.get(42), 0.01f);
+        }
     }
 }


### PR DESCRIPTION
If the index is `save()`ed to disk we should be able to load it without needing to either correctly guess the
parameters or hope they are ignored/overwritten when the index is loaded.