### PR TITLE
(breaking) FIX for unexpected segfault when index dimensions don't add up

### DIFF
--- a/rust/lib.rs
+++ b/rust/lib.rs
@@ -474,15 +474,6 @@ pub enum MetricFunction {
     F64Metric(std::boxed::Box<dyn Fn(*const f64, *const f64) -> Distance + Send + Sync>),
 }
 
-impl MetricFunction {
-    fn is_variable_length(&self) -> bool {
-        match self {
-            B1X8Metric => true,
-            _ => false,
-        }
-    }
-}
-
 /// Approximate Nearest Neighbors search index for dense vectors.
 ///
 /// The `Index` struct provides an abstraction over a dense vector space, allowing
@@ -556,9 +547,6 @@ impl Clone for ffi::IndexOptions {
 /// in an index. It supports generic operations on vectors of different types,
 /// allowing for the addition, retrieval, and search of vectors within an index.
 pub trait VectorType {
-    fn allow_variable_length() -> bool {
-        false
-    }
     /// Adds a vector to the index under the specified key.
     ///
     /// # Parameters
@@ -918,9 +906,6 @@ impl VectorType for f16 {
 }
 
 impl VectorType for b1x8 {
-    fn allow_variable_length() -> bool {
-        true
-    }
     fn search(index: &Index, query: &[Self], count: usize) -> Result<ffi::Matches, cxx::Exception> {
         index.inner.search_b1x8(b1x8::to_u8s(query), count)
     }

--- a/rust/lib.rs
+++ b/rust/lib.rs
@@ -474,6 +474,15 @@ pub enum MetricFunction {
     F64Metric(std::boxed::Box<dyn Fn(*const f64, *const f64) -> Distance + Send + Sync>),
 }
 
+impl MetricFunction {
+    fn is_variable_length(&self) -> bool {
+        match self {
+            B1X8Metric => true,
+            _ => false,
+        }
+    }
+}
+
 /// Approximate Nearest Neighbors search index for dense vectors.
 ///
 /// The `Index` struct provides an abstraction over a dense vector space, allowing
@@ -547,6 +556,9 @@ impl Clone for ffi::IndexOptions {
 /// in an index. It supports generic operations on vectors of different types,
 /// allowing for the addition, retrieval, and search of vectors within an index.
 pub trait VectorType {
+    fn allow_variable_length() -> bool {
+        false
+    }
     /// Adds a vector to the index under the specified key.
     ///
     /// # Parameters
@@ -906,6 +918,9 @@ impl VectorType for f16 {
 }
 
 impl VectorType for b1x8 {
+    fn allow_variable_length() -> bool {
+        true
+    }
     fn search(index: &Index, query: &[Self], count: usize) -> Result<ffi::Matches, cxx::Exception> {
         index.inner.search_b1x8(b1x8::to_u8s(query), count)
     }

--- a/rust/lib.rs
+++ b/rust/lib.rs
@@ -1389,8 +1389,12 @@ mod tests {
 
         let first: [f32; 5] = [0.2, 0.1, 0.2, 0.1, 0.3];
         let second: [f32; 5] = [0.3, 0.2, 0.4, 0.0, 0.1];
+        let too_long: [f32; 6] = [0.3, 0.2, 0.4, 0.0, 0.1, 0.1];
+        let too_short: [f32; 4] = [0.3, 0.2, 0.4, 0.0];
         assert!(index.add(1, &first).is_ok());
         assert!(index.add(2, &second).is_ok());
+        assert!(index.add(3, &too_long).is_err());
+        assert!(index.add(4, &too_short).is_err());
         assert_eq!(index.size(), 2);
 
         // Test using Vec<T>

--- a/rust/lib.rs
+++ b/rust/lib.rs
@@ -1397,6 +1397,27 @@ mod tests {
         let result = index.get(1, &mut found);
         assert!(result.is_err());
     }
+    #[test]
+    fn test_search_vector() {
+        let mut options = IndexOptions::default();
+        options.dimensions = 5;
+        options.quantization = ScalarKind::F32;
+        let index = Index::new(&options).unwrap();
+        assert!(index.reserve(10).is_ok());
+
+        let first: [f32; 5] = [0.2, 0.1, 0.2, 0.1, 0.3];
+        let second: [f32; 5] = [0.3, 0.2, 0.4, 0.0, 0.1];
+        let too_long: [f32; 6] = [0.3, 0.2, 0.4, 0.0, 0.1, 0.1];
+        let too_short: [f32; 4] = [0.3, 0.2, 0.4, 0.0];
+        assert!(index.add(1, &first).is_ok());
+        assert!(index.add(2, &second).is_ok());
+        assert_eq!(index.size(), 2);
+        //assert!(index.add(3, &too_long).is_err());
+        //assert!(index.add(4, &too_short).is_err());
+
+        assert!(index.search(&too_long, 1).is_err());
+        assert!(index.search(&too_short, 1).is_err());
+    }
 
     #[test]
     fn test_add_remove_vector() {

--- a/rust/lib.rs
+++ b/rust/lib.rs
@@ -474,6 +474,15 @@ pub enum MetricFunction {
     F64Metric(std::boxed::Box<dyn Fn(*const f64, *const f64) -> Distance + Send + Sync>),
 }
 
+impl MetricFunction {
+    fn is_variable_length(&self) -> bool {
+        match self {
+            B1X8Metric => true,
+            _ => false,
+        }
+    }
+}
+
 /// Approximate Nearest Neighbors search index for dense vectors.
 ///
 /// The `Index` struct provides an abstraction over a dense vector space, allowing
@@ -547,6 +556,9 @@ impl Clone for ffi::IndexOptions {
 /// in an index. It supports generic operations on vectors of different types,
 /// allowing for the addition, retrieval, and search of vectors within an index.
 pub trait VectorType {
+    fn allow_variable_length() -> bool {
+        false
+    }
     /// Adds a vector to the index under the specified key.
     ///
     /// # Parameters
@@ -906,6 +918,9 @@ impl VectorType for f16 {
 }
 
 impl VectorType for b1x8 {
+    fn allow_variable_length() -> bool {
+        true
+    }
     fn search(index: &Index, query: &[Self], count: usize) -> Result<ffi::Matches, cxx::Exception> {
         index.inner.search_b1x8(b1x8::to_u8s(query), count)
     }
@@ -978,6 +993,14 @@ impl VectorType for b1x8 {
 
 fn wrap_cxx_exception<T>(error: Result<T, cxx::Exception>) -> Result<T, USearchError> {
     error.map_err(|cxx_error| USearchError::CxxException(cxx_error))
+}
+use std::any::type_name;
+fn type_of<T>(_: T) -> &'static str {
+    type_name::<T>()
+}
+fn allow_different_dimensions<T>(type_check: T) -> bool {
+    let checktype: &[b1x8] = &[b1x8(0b00001111)];
+    type_of(type_check) == type_of(checktype)
 }
 
 impl Index {
@@ -1083,13 +1106,15 @@ impl Index {
     /// * `vector` - A slice containing the vector data.
     pub fn add<T: VectorType>(self: &Index, key: Key, vector: &[T]) -> Result<(), USearchError> {
         if vector.len() == self.dimensions() {
-            wrap_cxx_exception(T::add(self, key, vector))
-        } else {
-            Err(USearchError::WrongDimensionSize(
-                vector.len(),
-                self.dimensions(),
-            ))
+            return wrap_cxx_exception(T::add(self, key, vector));
         }
+        if allow_different_dimensions(vector) {
+            return wrap_cxx_exception(T::add(self, key, vector));
+        }
+        Err(USearchError::WrongDimensionSize(
+            vector.len(),
+            self.dimensions(),
+        ))
     }
 
     /// Extracts one or more vectors matching the specified key.

--- a/rust/lib.rs
+++ b/rust/lib.rs
@@ -41,11 +41,6 @@ pub enum BitAddressableError {
     /// Error indicating the specified index is out of the allowable range.
     IndexOutOfRange,
 }
-#[derive(Debug)]
-pub enum USearchError {
-    CxxException(cxx::Exception),
-    WrongDimensionSize(usize, usize),
-}
 
 impl std::fmt::Display for BitAddressableError {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
@@ -1077,15 +1072,8 @@ impl Index {
     ///
     /// * `key` - The key associated with the vector.
     /// * `vector` - A slice containing the vector data.
-    pub fn add<T: VectorType>(self: &Index, key: Key, vector: &[T]) -> Result<(), USearchError> {
-        if vector.len() == self.dimensions() {
-            T::add(self, key, vector).map_err(|cxx_error| USearchError::CxxException(cxx_error))
-        } else {
-            Err(USearchError::WrongDimensionSize(
-                vector.len(),
-                self.dimensions(),
-            ))
-        }
+    pub fn add<T: VectorType>(self: &Index, key: Key, vector: &[T]) -> Result<(), cxx::Exception> {
+        T::add(self, key, vector)
     }
 
     /// Extracts one or more vectors matching the specified key.

--- a/rust/lib.rs
+++ b/rust/lib.rs
@@ -976,19 +976,15 @@ impl VectorType for b1x8 {
     }
 }
 
-fn wrap_cxx_exception<T>(error: Result<T, cxx::Exception>) -> Result<T, USearchError> {
-    error.map_err(|cxx_error| USearchError::CxxException(cxx_error))
-}
-
 impl Index {
-    pub fn new(options: &ffi::IndexOptions) -> Result<Self, USearchError> {
-        wrap_cxx_exception(match ffi::new_native_index(options) {
+    pub fn new(options: &ffi::IndexOptions) -> Result<Self, cxx::Exception> {
+        match ffi::new_native_index(options) {
             Ok(inner) => Result::Ok(Self {
                 inner,
                 metric_fn: None,
             }),
             Err(err) => Err(err),
-        })
+        }
     }
 
     /// Retrieves the expansion value used during index creation.
@@ -1047,8 +1043,8 @@ impl Index {
         self: &Index,
         query: &[T],
         count: usize,
-    ) -> Result<ffi::Matches, USearchError> {
-        wrap_cxx_exception(T::search(self, query, count))
+    ) -> Result<ffi::Matches, cxx::Exception> {
+        T::search(self, query, count)
     }
 
     /// Performs k-Approximate Nearest Neighbors (kANN) Search for closest vectors to the provided query
@@ -1068,11 +1064,11 @@ impl Index {
         query: &[T],
         count: usize,
         filter: F,
-    ) -> Result<ffi::Matches, USearchError>
+    ) -> Result<ffi::Matches, cxx::Exception>
     where
         F: Fn(Key) -> bool,
     {
-        wrap_cxx_exception(T::filtered_search(self, query, count, filter))
+        T::filtered_search(self, query, count, filter)
     }
 
     /// Adds a vector with a specified key to the index.
@@ -1083,7 +1079,7 @@ impl Index {
     /// * `vector` - A slice containing the vector data.
     pub fn add<T: VectorType>(self: &Index, key: Key, vector: &[T]) -> Result<(), USearchError> {
         if vector.len() == self.dimensions() {
-            wrap_cxx_exception(T::add(self, key, vector))
+            T::add(self, key, vector).map_err(|cxx_error| USearchError::CxxException(cxx_error))
         } else {
             Err(USearchError::WrongDimensionSize(
                 vector.len(),
@@ -1107,8 +1103,8 @@ impl Index {
         self: &Index,
         key: Key,
         vector: &mut [T],
-    ) -> Result<usize, USearchError> {
-        wrap_cxx_exception(T::get(self, key, vector))
+    ) -> Result<usize, cxx::Exception> {
+        T::get(self, key, vector)
     }
 
     /// Extracts one or more vectors matching specified key into supplied resizable vector.
@@ -1122,16 +1118,16 @@ impl Index {
         self: &Index,
         key: Key,
         vector: &mut Vec<T>,
-    ) -> Result<usize, USearchError> {
+    ) -> Result<usize, cxx::Exception> {
         let dim = self.dimensions();
         let max_matches = self.count(key);
         vector.resize(dim * max_matches, T::default());
         let matches = T::get(self, key, &mut vector[..]);
         if matches.is_err() {
-            return wrap_cxx_exception(matches);
+            return matches;
         }
         vector.resize(dim * matches.as_ref().unwrap(), T::default());
-        return wrap_cxx_exception(matches);
+        return matches;
     }
 
     /// Reserves memory for a specified number of incoming vectors.
@@ -1139,8 +1135,8 @@ impl Index {
     /// # Arguments
     ///
     /// * `capacity` - The desired total capacity, including the current size.
-    pub fn reserve(self: &Index, capacity: usize) -> Result<(), USearchError> {
-        wrap_cxx_exception(self.inner.reserve(capacity))
+    pub fn reserve(self: &Index, capacity: usize) -> Result<(), cxx::Exception> {
+        self.inner.reserve(capacity)
     }
 
     /// Retrieves the number of dimensions in the vectors indexed.
@@ -1177,8 +1173,8 @@ impl Index {
     /// # Returns
     ///
     /// `true` if the vector is successfully removed, `false` otherwise.
-    pub fn remove(self: &Index, key: Key) -> Result<usize, USearchError> {
-        wrap_cxx_exception(self.inner.remove(key))
+    pub fn remove(self: &Index, key: Key) -> Result<usize, cxx::Exception> {
+        self.inner.remove(key)
     }
 
     /// Renames the vector under a specific key.
@@ -1191,8 +1187,8 @@ impl Index {
     /// # Returns
     ///
     /// `true` if the vector is renamed, `false` otherwise.
-    pub fn rename(self: &Index, from: Key, to: Key) -> Result<usize, USearchError> {
-        wrap_cxx_exception(self.inner.rename(from, to))
+    pub fn rename(self: &Index, from: Key, to: Key) -> Result<usize, cxx::Exception> {
+        self.inner.rename(from, to)
     }
 
     /// Checks if the index contains a vector with a specified key.
@@ -1226,8 +1222,8 @@ impl Index {
     /// # Arguments
     ///
     /// * `path` - The file path where the index will be saved.
-    pub fn save(self: &Index, path: &str) -> Result<(), USearchError> {
-        wrap_cxx_exception(self.inner.save(path))
+    pub fn save(self: &Index, path: &str) -> Result<(), cxx::Exception> {
+        self.inner.save(path)
     }
 
     /// Loads the index from a specified file.
@@ -1235,8 +1231,8 @@ impl Index {
     /// # Arguments
     ///
     /// * `path` - The file path from where the index will be loaded.
-    pub fn load(self: &Index, path: &str) -> Result<(), USearchError> {
-        wrap_cxx_exception(self.inner.load(path))
+    pub fn load(self: &Index, path: &str) -> Result<(), cxx::Exception> {
+        self.inner.load(path)
     }
 
     /// Creates a view of the index from a file without loading it into memory.
@@ -1244,13 +1240,13 @@ impl Index {
     /// # Arguments
     ///
     /// * `path` - The file path from where the view will be created.
-    pub fn view(self: &Index, path: &str) -> Result<(), USearchError> {
-        wrap_cxx_exception(self.inner.view(path))
+    pub fn view(self: &Index, path: &str) -> Result<(), cxx::Exception> {
+        self.inner.view(path)
     }
 
     /// Erases all members from the index, closes files, and returns RAM to OS.
-    pub fn reset(self: &Index) -> Result<(), USearchError> {
-        wrap_cxx_exception(self.inner.reset())
+    pub fn reset(self: &Index) -> Result<(), cxx::Exception> {
+        self.inner.reset()
     }
 
     /// A relatively accurate lower bound on the amount of memory consumed by the system.
@@ -1264,8 +1260,8 @@ impl Index {
     /// # Arguments
     ///
     /// * `path` - The file path where the index will be saved.
-    pub fn save_to_buffer(self: &Index, buffer: &mut [u8]) -> Result<(), USearchError> {
-        wrap_cxx_exception(self.inner.save_to_buffer(buffer))
+    pub fn save_to_buffer(self: &Index, buffer: &mut [u8]) -> Result<(), cxx::Exception> {
+        self.inner.save_to_buffer(buffer)
     }
 
     /// Loads the index from a specified file.
@@ -1273,8 +1269,8 @@ impl Index {
     /// # Arguments
     ///
     /// * `path` - The file path from where the index will be loaded.
-    pub fn load_from_buffer(self: &Index, buffer: &[u8]) -> Result<(), USearchError> {
-        wrap_cxx_exception(self.inner.load_from_buffer(buffer))
+    pub fn load_from_buffer(self: &Index, buffer: &[u8]) -> Result<(), cxx::Exception> {
+        self.inner.load_from_buffer(buffer)
     }
 
     /// Creates a view of the index from a file without loading it into memory.
@@ -1282,12 +1278,12 @@ impl Index {
     /// # Arguments
     ///
     /// * `path` - The file path from where the view will be created.
-    pub fn view_from_buffer(self: &Index, buffer: &[u8]) -> Result<(), USearchError> {
-        wrap_cxx_exception(self.inner.view_from_buffer(buffer))
+    pub fn view_from_buffer(self: &Index, buffer: &[u8]) -> Result<(), cxx::Exception> {
+        self.inner.view_from_buffer(buffer)
     }
 }
 
-pub fn new_index(options: &ffi::IndexOptions) -> Result<Index, USearchError> {
+pub fn new_index(options: &ffi::IndexOptions) -> Result<Index, cxx::Exception> {
     Index::new(options)
 }
 


### PR DESCRIPTION
This should fix the problem of segfaulting by checking whether the dimensions are adding up and handling the edge case of hamming distance.
Due to `cxx::Exception` being private I had to create a new error type that wraps C++ Exceptions and can output errors from "rustland".
**Therefore this fix could introduce breaking changes** 
It works in my (small) codebase and passes tests, but due to finding more cases that cause an unexpected segfault in rust, I suggest merging these fixes together later.