### PR TITLE
Clamp before downcasting in float to i8 conversions

### DIFF
--- a/include/usearch/index_plugins.hpp
+++ b/include/usearch/index_plugins.hpp
@@ -336,7 +336,7 @@ class f16_bits_t {
     inline f16_bits_t(float v) noexcept : uint16_(f32_to_f16(v)) {}
     inline f16_bits_t(double v) noexcept : uint16_(f32_to_f16(static_cast<float>(v))) {}
 
-    inline bool operator<(const f16_bits_t& other) const noexcept { return uint16_ < other.uint16_; }
+    inline bool operator<(const f16_bits_t& other) const noexcept { return float(*this) < float(other); }
 
     inline f16_bits_t operator+(f16_bits_t other) const noexcept { return {float(*this) + float(other)}; }
     inline f16_bits_t operator-(f16_bits_t other) const noexcept { return {float(*this) - float(other)}; }
@@ -963,8 +963,9 @@ class i8_converted_t {
     inline explicit operator std::int32_t() const noexcept { return int8_; }
     inline explicit operator std::int64_t() const noexcept { return int8_; }
 
+    // Even with `f16_t` arguments we may want to use `f32_t` for clamping and comparions.
     inline i8_converted_t(f16_t v)
-        : int8_(static_cast<std::int8_t>(usearch::clamp<f16_t>(v * divisor_k, min_k, max_k))) {}
+        : int8_(static_cast<std::int8_t>(usearch::clamp<f32_t>(v * divisor_k, min_k, max_k))) {}
     inline i8_converted_t(f32_t v)
         : int8_(static_cast<std::int8_t>(usearch::clamp<f32_t>(v * divisor_k, min_k, max_k))) {}
     inline i8_converted_t(f64_t v)

--- a/include/usearch/index_plugins.hpp
+++ b/include/usearch/index_plugins.hpp
@@ -331,9 +331,12 @@ class f16_bits_t {
     inline explicit operator bool() const noexcept { return f16_to_f32(uint16_) > 0.5f; }
 
     inline f16_bits_t(i8_converted_t) noexcept;
+    inline f16_bits_t(std::int8_t v) noexcept : uint16_(v) {}
     inline f16_bits_t(bool v) noexcept : uint16_(f32_to_f16(v)) {}
     inline f16_bits_t(float v) noexcept : uint16_(f32_to_f16(v)) {}
     inline f16_bits_t(double v) noexcept : uint16_(f32_to_f16(static_cast<float>(v))) {}
+
+    inline bool operator<(const f16_bits_t& other) const noexcept { return uint16_ < other.uint16_; }
 
     inline f16_bits_t operator+(f16_bits_t other) const noexcept { return {float(*this) + float(other)}; }
     inline f16_bits_t operator-(f16_bits_t other) const noexcept { return {float(*this) - float(other)}; }
@@ -961,11 +964,11 @@ class i8_converted_t {
     inline explicit operator std::int64_t() const noexcept { return int8_; }
 
     inline i8_converted_t(f16_t v)
-        : int8_(usearch::clamp<std::int8_t>(static_cast<std::int8_t>(v * divisor_k), min_k, max_k)) {}
+        : int8_(static_cast<std::int8_t>(usearch::clamp<f16_t>(v * divisor_k, min_k, max_k))) {}
     inline i8_converted_t(f32_t v)
-        : int8_(usearch::clamp<std::int8_t>(static_cast<std::int8_t>(v * divisor_k), min_k, max_k)) {}
+        : int8_(static_cast<std::int8_t>(usearch::clamp<f32_t>(v * divisor_k, min_k, max_k))) {}
     inline i8_converted_t(f64_t v)
-        : int8_(usearch::clamp<std::int8_t>(static_cast<std::int8_t>(v * divisor_k), min_k, max_k)) {}
+        : int8_(static_cast<std::int8_t>(usearch::clamp<f64_t>(v * divisor_k, min_k, max_k))) {}
 };
 
 f16_bits_t::f16_bits_t(i8_converted_t v) noexcept : uint16_(f32_to_f16(v)) {}


### PR DESCRIPTION
    Previously we were downcasting floats to the target type (e.g. int8_t), and then
    clamping to [-100, 100] range. This means that e.g. 129 would be cast to -127 and
    then converted to -100, in stead of becoming 100

    The fix does clamping first, and then casts the resulting number
    (which is guaranteed to be in range [-100, 100], due to clamping)
    from source type to target int8_t. Given the clamping, this will never overflow.