### PR TITLE
Reset cast buffer so it can be set with bitwise ORs

### DIFF
--- a/include/usearch/index_plugins.hpp
+++ b/include/usearch/index_plugins.hpp
@@ -906,6 +906,7 @@ template <typename from_scalar_at> struct cast_gt<from_scalar_at, b1x8_t> {
     inline static bool try_(byte_t const* input, std::size_t dim, byte_t* output) noexcept {
         from_scalar_at const* typed_input = reinterpret_cast<from_scalar_at const*>(input);
         unsigned char* typed_output = reinterpret_cast<unsigned char*>(output);
+        std::memset(typed_output, 0, dim / CHAR_BIT);
         for (std::size_t i = 0; i != dim; ++i)
             // Converting from scalar types to boolean isn't trivial and depends on the type.
             // The most common case is to consider all positive values as `true` and all others as `false`.


### PR DESCRIPTION
When converting floating point arrays to binary, we use bitwise OR operations to set the relevant bits in the output
buffer to 1. We do nothing if the bit is zero, so we assume that the bit is zero to start with.
The `memset` statement makes sure this assumption holds.