### PR TITLE
Fix: Java JAR contains native library twice

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -118,10 +118,6 @@ test {
 
 jar {
     dependsOn("usearchSharedLibrary")
-    from("$buildDir/libs/usearch/shared") {
-        include "libusearch.so", "libusearch.dylib", "libusearch.dll"
-        into "usearch"
-    }
     from sourceSets.main.output
 }
 

--- a/java/cloud/unum/usearch/Index.java
+++ b/java/cloud/unum/usearch/Index.java
@@ -375,9 +375,9 @@ public class Index implements AutoCloseable {
     } catch (UnsatisfiedLinkError e) {
       try {
         if (System.getProperty("os.name").equals("Mac OS X")) {
-          NativeUtils.loadLibraryFromJar("/usearch/libusearch.dylib");
+          NativeUtils.loadLibraryFromJar("/usearch/shared/libusearch.dylib");
         } else {
-          NativeUtils.loadLibraryFromJar("/usearch/libusearch.so");
+          NativeUtils.loadLibraryFromJar("/usearch/shared/libusearch.so");
         }
       } catch (IOException e1) {
         throw new RuntimeException(e1);


### PR DESCRIPTION
This PR fixes https://github.com/unum-cloud/usearch/issues/314 by excluding the shared/ directory.

Tested with

```
javac -cp /usr/share/java/junit4.jar:../../build/libs/usearch-2.13.0.jar IndexTest.java
java -cp .:/usr/share/java/junit4.jar org.junit.runner.JUnitCore IndexTest
```