### PR TITLE
Fix: build.gradle deprecations

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,8 +10,10 @@ plugins {
 group "cloud.unum"
 version = file("VERSION").text.trim()
 
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+java {
+    sourceCompatibility = JavaVersion.VERSION_18
+    targetCompatibility = JavaVersion.VERSION_18
+}
 
 repositories {
     mavenCentral()


### PR DESCRIPTION
This PR fixes the following deprecation warnings. 

```
Build file '/home/ch/code/mr/usearch/build.gradle': line 13
The org.gradle.api.plugins.JavaPluginConvention type has been deprecated. This is scheduled to be removed in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/8.8/userguide/upgrading_version_8.html#java_convention_deprecation
        at build_6knh5cblxyylcg5a00yqlwx4w.run(/home/ch/code/mr/usearch/build.gradle:13)
        (Run with --stacktrace to get the full stack trace of this deprecation warning.)
Build file '/home/ch/code/mr/usearch/build.gradle': line 14
The org.gradle.api.plugins.JavaPluginConvention type has been deprecated. This is scheduled to be removed in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/8.8/userguide/upgrading_version_8.html#java_convention_deprecation
        at build_6knh5cblxyylcg5a00yqlwx4w.run(/home/ch/code/mr/usearch/build.gradle:14)
        (Run with --stacktrace to get the full stack trace of this deprecation warning.)
```
