### PR TITLE
Fix: ESM build support

### DIFF
--- a/javascript/tsconfig-esm.json
+++ b/javascript/tsconfig-esm.json
@@ -3,6 +3,7 @@
     "compilerOptions": {
         "module": "esnext",
         "outDir": "dist/esm",
-        "target": "esnext"
+        "target": "esnext",
+        "esModuleInterop": true,
     }
 }

--- a/javascript/usearch.ts
+++ b/javascript/usearch.ts
@@ -609,6 +609,16 @@ function exactSearch(
   }
 }
 
+const usearch = {
+    Index,
+    MetricKind,
+    ScalarKind,
+    Matches,
+    BatchMatches,
+    exactSearch,
+};
+export default usearch;
+
 // utility functions to help find native builds
 
 function getBuildDir(dir: string) {


### PR DESCRIPTION
This PR fixes https://github.com/unum-cloud/usearch/issues/426 by adding `"esModuleInterop": true` to `tsconfig-esm.json` and 

```
const usearch = {
    Index,
    MetricKind,
    ScalarKind,
    Matches,
    BatchMatches,
    exactSearch,
};
export default usearch;
```
 to the `usearch.ts` file.