### PR TITLE
Docs: contributing/javascript: add the run of `npm install`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -227,6 +227,7 @@ Testing and benchmarking:
 
 ```sh
 npm install -g typescript
+npm install
 npm run build-js
 npm test
 npm run bench


### PR DESCRIPTION
I got the following error when I ran it as per the documentation.

```
$ npm run build-js

> usearch@2.14.0 build-js
> tsc -p javascript/tsconfig-esm.json && tsc -p javascript/tsconfig-cjs.json && cp javascript/dist-package-esm.json javascript/dist/esm/package.json && cp javascript/dist-package-cjs.json javascript/dist/cjs/package.json

error TS2688: Cannot find type definition file for 'node'.
  The file is in the program because:
    Entry point of type library 'node' specified in compilerOptions

Found 1 error.
```

Add `npm install` is missing.