### PR TITLE
Fix: Add a comma

### DIFF
--- a/objc/include/USearchObjective.h
+++ b/objc/include/USearchObjective.h
@@ -9,7 +9,7 @@ typedef NS_ENUM(NSUInteger, USearchScalar) {
     USearchScalarF16,
     USearchScalarF64,
     USearchScalarI8,
-    USearchScalarB1
+    USearchScalarB1,
     USearchScalarBF16,
 };
 


### PR DESCRIPTION
Fix the following build error:

```
 In file included from /Users/runner/work/usearch/usearch/objc/USearchObjective.mm:1:
/Users/runner/work/usearch/usearch/objc/include/USearchObjective.h:12:20: error: missing ',' between enumerators
    USearchScalarB1
                   ^
                   ,
1 error generated.
```