### PR TITLE
Docs: Update JavaScript code example

### DIFF
--- a/javascript/README.md
+++ b/javascript/README.md
@@ -21,8 +21,9 @@ wasmer install unum/usearch
 Create an index, add vectors, and perform searches with ease:
 
 ```js
+const assert = require('node:assert');
 const usearch = require('usearch');
-const index = new usearch.Index({ metric: 'cos', connectivity: 16, dimensions: 3 });
+const index = new usearch.Index({ metric: 'l2sq', connectivity: 16, dimensions: 3 });
 index.add(42n, new Float32Array([0.2, 0.6, 0.4]));
 const results = index.search(new Float32Array([0.2, 0.6, 0.4]), 10);
 


### PR DESCRIPTION
### 1. Add `require('node:assert')`

Fix the following error:
```
ReferenceError: assert is not defined
```

### 2. Change metric to `l2sq`

Fix the following error:
```
AssertionError [ERR_ASSERTION]: Expected values to be loosely deep-equal:

Float32Array(1) [
  -0.00017893314361572266
]

should loosely deep-equal

Float32Array(1) [
  0
]
```

Reference:. https://github.com/unum-cloud/usearch/blob/242be104de770c12ed1fc938215530b944000b42/javascript/usearch.test.js#L49-L61