### PR TITLE
Fix: JavaScript Fix error when searching after load() and view()

### DIFF
--- a/javascript/lib.cpp
+++ b/javascript/lib.cpp
@@ -129,6 +129,7 @@ void CompiledIndex::Load(Napi::CallbackInfo const& ctx) {
         auto result = native_->load(path.c_str());
         if (!result)
             Napi::TypeError::New(ctx.Env(), result.error.release()).ThrowAsJavaScriptException();
+        native_->reserve(ceil2(native_->size()));
 
     } catch (...) {
         Napi::TypeError::New(ctx.Env(), "Loading failed").ThrowAsJavaScriptException();
@@ -142,6 +143,7 @@ void CompiledIndex::View(Napi::CallbackInfo const& ctx) {
         auto result = native_->view(path.c_str());
         if (!result)
             Napi::TypeError::New(ctx.Env(), result.error.release()).ThrowAsJavaScriptException();
+        native_->reserve(ceil2(native_->size()));
 
     } catch (...) {
         Napi::TypeError::New(ctx.Env(), "Memory-mapping failed").ThrowAsJavaScriptException();

--- a/javascript/lib.cpp
+++ b/javascript/lib.cpp
@@ -129,7 +129,8 @@ void CompiledIndex::Load(Napi::CallbackInfo const& ctx) {
         auto result = native_->load(path.c_str());
         if (!result)
             Napi::TypeError::New(ctx.Env(), result.error.release()).ThrowAsJavaScriptException();
-        native_->reserve(ceil2(native_->size()));
+        if (!native_->try_reserve(ceil2(native_->size())))
+            Napi::Error::New(ctx.Env(), "Failed to reserve memory").ThrowAsJavaScriptException();
 
     } catch (...) {
         Napi::TypeError::New(ctx.Env(), "Loading failed").ThrowAsJavaScriptException();
@@ -143,7 +144,8 @@ void CompiledIndex::View(Napi::CallbackInfo const& ctx) {
         auto result = native_->view(path.c_str());
         if (!result)
             Napi::TypeError::New(ctx.Env(), result.error.release()).ThrowAsJavaScriptException();
-        native_->reserve(ceil2(native_->size()));
+        if (!native_->try_reserve(ceil2(native_->size())))
+            Napi::Error::New(ctx.Env(), "Failed to reserve memory").ThrowAsJavaScriptException();
 
     } catch (...) {
         Napi::TypeError::New(ctx.Env(), "Memory-mapping failed").ThrowAsJavaScriptException();


### PR DESCRIPTION
I got an error when I loaded and searched with load() or view().

Code Example:
```js
// Saved with `index.save('index.usearch');` in another script.
index.load('index.usearch');
const results = index.search(new Float32Array([0.2, 0.6, 0.4]), 10);
```

Error:
```
/build/javascript/dist/cjs/usearch.js:314
        const result = __classPrivateFieldGet(this, _Index_compiledIndex, "f").search(normalizedVectors, k);
                                                                               ^

TypeError: Search failed
    at Index.search (/build/javascript/dist/cjs/usearch.js:314:80)
    at Object.<anonymous> (/build/example.js:9:21)
    at Module._compile (node:internal/modules/cjs/loader:1469:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1548:10)
    at Module.load (node:internal/modules/cjs/loader:1288:32)
    at Module._load (node:internal/modules/cjs/loader:1104:12)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:174:12)
    at node:internal/main/run_main_module:28:49

Node.js v20.17.0
```

This bug fixed.