### PR TITLE
Fix: JavaScript Fix bug in add() that aborts with invalid operations

### DIFF
--- a/javascript/lib.cpp
+++ b/javascript/lib.cpp
@@ -161,7 +161,11 @@ void CompiledIndex::Add(Napi::CallbackInfo const& ctx) {
     auto run_parallel = [&](auto vectors) {
         executor_stl_t executor;
         executor.fixed(tasks, [&](std::size_t /*thread_idx*/, std::size_t task_idx) {
-            native_->add(static_cast<default_key_t>(keys[task_idx]), vectors + task_idx * native_->dimensions());
+            try {
+                native_->add(static_cast<default_key_t>(keys[task_idx]), vectors + task_idx * native_->dimensions());
+            } catch (const std::runtime_error& e) {
+                Napi::Error::New(ctx.Env(), e.what()).ThrowAsJavaScriptException();
+            }
         });
     };
 

--- a/javascript/usearch.test.js
+++ b/javascript/usearch.test.js
@@ -82,3 +82,21 @@ test('Operations with invalid values', () => {
         assert.equal(err.message, 'Vectors must be a TypedArray or an array of arrays.');
     }
 });
+
+test('Invalid operations', async (t) => {
+    await t.test('Add the same keys', () => {
+        const index = new usearch.Index({
+            metric: "l2sq",
+            connectivity: 16,
+            dimensions: 3,
+        });
+        index.add(42n, new Float32Array([0.2, 0.6, 0.4]));
+        assert.throws(
+            () => index.add(42n, new Float32Array([0.2, 0.6, 0.4])),
+            {
+                name: 'Error',
+                message: 'Duplicate keys not allowed in high-level wrappers'
+            }
+        )
+    })
+});

--- a/javascript/usearch.test.js
+++ b/javascript/usearch.test.js
@@ -97,6 +97,6 @@ test('Invalid operations', async (t) => {
                 name: 'Error',
                 message: 'Duplicate keys not allowed in high-level wrappers'
             }
-        )
-    })
+        );
+    });
 });


### PR DESCRIPTION
For example, if you try to add the same key, it aborts.

```
terminate called after throwing an instance of 'std::runtime_error'
  what():  Duplicate keys not allowed in high-level wrappers
Aborted (core dumped)
```

Improved error handling to throw JavaScript exceptions.