### PR TITLE
Make Index sendable and syncable

### DIFF
--- a/rust/lib.rs
+++ b/rust/lib.rs
@@ -512,6 +512,10 @@ pub struct Index {
     metric_fn: Option<MetricFunction>,
 }
 
+unsafe impl Send for Index {}
+unsafe impl Sync for Index {}
+
+
 impl Default for ffi::IndexOptions {
     fn default() -> Self {
         Self {


### PR DESCRIPTION

Solved the issue ```*const cxx::void` cannot be shared between threads safely``` and makes index concurrent for use in Rayon or Actix-web. Example is in https://github.com/jbrummack/create_index

See  #482