### PR TITLE
Fix: JavaScript Change the return value of index.count() to a number

### DIFF
--- a/javascript/lib.cpp
+++ b/javascript/lib.cpp
@@ -268,7 +268,7 @@ Napi::Value CompiledIndex::Count(Napi::CallbackInfo const& ctx) {
     std::size_t length = keys.ElementLength();
     Napi::Array result = Napi::Array::New(env, length);
     for (std::size_t i = 0; i < length; ++i)
-        result[i] = Napi::Boolean::New(env, native_->count(static_cast<default_key_t>(keys[i])));
+        result[i] = Napi::Number::New(env, native_->count(static_cast<default_key_t>(keys[i])));
     return result;
 }
 

--- a/javascript/usearch.test.js
+++ b/javascript/usearch.test.js
@@ -60,7 +60,27 @@ test("Expected results", () => {
     assertAlmostEqual(results.distances[0], new Float32Array([0]));
 });
 
+test('Expected count()', async (t) => {
+    const index = new usearch.Index({
+        metric: 'l2sq',
+        connectivity: 16,
+        dimensions: 3,
+    });
+    index.add(
+        [42n, 43n],
+        [new Float32Array([0.2, 0.6, 0.4]), new Float32Array([0.2, 0.6, 0.4])]
+    );
 
+    await t.test('Argument is a number', () => {
+        assert.equal(1, index.count(43n));
+    });
+    await t.test('Argument is a number (does not exist)', () => {
+        assert.equal(0, index.count(44n));
+    });
+    await t.test('Argument is an array', () => {
+        assert.deepEqual([1, 1, 0], index.count([42n, 43n, 44n]));
+    });
+});
 
 test('Operations with invalid values', () => {
     const indexBatch = new usearch.Index(2, 'l2sq');


### PR DESCRIPTION
The return value of index.count() was a boolean, so it was changed to a number.