### PR TITLE
Add getters for precomputed constants for observability

### DIFF
--- a/include/usearch/index.hpp
+++ b/include/usearch/index.hpp
@@ -3175,6 +3175,18 @@ class index_gt {
 
     std::size_t memory_usage_per_node(level_t level) const noexcept { return node_bytes_(level); }
 
+    double inverse_log_connectivity() const {
+        return pre_.inverse_log_connectivity;
+    }
+
+    std::size_t neighbors_base_bytes() const {
+        return pre_.neighbors_base_bytes;
+    }
+
+    std::size_t neighbors_bytes() const {
+        return pre_.neighbors_bytes;
+    }
+
 #if defined(USEARCH_USE_PRAGMA_REGION)
 #pragma endregion
 

--- a/include/usearch/index_dense.hpp
+++ b/include/usearch/index_dense.hpp
@@ -693,6 +693,9 @@ class index_dense_gt {
     std::size_t max_level() const { return typed_->max_level(); }
     index_dense_config_t const& config() const { return config_; }
     index_limits_t const& limits() const { return typed_->limits(); }
+    double inverse_log_connectivity() const { return typed_->inverse_log_connectivity(); }
+    std::size_t neighbors_base_bytes() const { return typed_->neighbors_base_bytes(); }
+    std::size_t neighbors_bytes() const { return typed_->neighbors_bytes(); }
     bool multi() const { return config_.multi; }
     std::size_t currently_available_threads() const {
         std::unique_lock<std::mutex> available_threads_lock(available_threads_mutex_);


### PR DESCRIPTION
We would like to have access to these precomputed constants so we can display them to the database operator and compare them against similarly configured indexes with other HNSW implementations.