### PR TITLE
Fix: JS: Improve error handling of batch addition

### DIFF
--- a/javascript/lib.cpp
+++ b/javascript/lib.cpp
@@ -173,7 +173,12 @@ void CompiledIndex::Add(Napi::CallbackInfo const& ctx) {
                                                vectors + task_idx * native_->dimensions());
             if (!result) {
                 std::lock_guard<std::mutex> lock(mtx);
-                error += "<key:" + std::to_string(keys[task_idx]) + " message:" + result.error.release() + ">";
+                error
+                    .append("<key:")
+                    .append(std::to_string(keys[task_idx]))
+                    .append(" message:")
+                    .append(result.error.release())
+                    .append(">");
             }
         });
         if (error.size() > 0)

--- a/javascript/usearch.test.js
+++ b/javascript/usearch.test.js
@@ -166,7 +166,28 @@ test('Invalid operations', async (t) => {
             () => index.add(42n, new Float32Array([0.2, 0.6, 0.4])),
             {
                 name: 'Error',
-                message: 'Duplicate keys not allowed in high-level wrappers'
+                message: '<key:42 message:Duplicate keys not allowed in high-level wrappers>'
+            }
+        );
+    });
+
+    await t.test('Batch add containing the same key', () => {
+        const index = new usearch.Index({
+            metric: "l2sq",
+            connectivity: 16,
+            dimensions: 3,
+        });
+        index.add(42n, new Float32Array([0.2, 0.6, 0.4]));
+        assert.throws(
+            () =>  {
+              index.add(
+                [41n, 42n, 43n],
+                [[0.1, 0.6, 0.4], [0.2, 0.6, 0.4], [0.3, 0.6, 0.4]]
+              );
+            },
+            {
+                name: 'Error',
+                message: '<key:42 message:Duplicate keys not allowed in high-level wrappers>'
             }
         );
     });
@@ -232,7 +253,7 @@ test('Serialization', async (t) => {
             () => index.add(43n, new Float32Array([0.2, 0.6, 0.4])),
             {
                 name: 'Error',
-                message: "Can't add to an immutable index"
+                message: "<key:43 message:Can't add to an immutable index>"
             }
         );
     });


### PR DESCRIPTION
Crash if there is an error in batch addition.
Example:

```js
const usearch = require('usearch');
const index = new usearch.Index({ metric: 'l2sq', connectivity: 16, dimensions: 3 });
index.add(42n, new Float32Array([0.2, 0.6, 0.4]));
index.add(
  [41n, 42n, 43n],
  [[0.1, 0.6, 0.4], [0.2, 0.6, 0.4], [0.3, 0.6, 0.4]]
)
```

`42n` is duplicated, which causes an error, but then it crash.

It seems that it is not better to throw an exception during the process, so we changed it to throw it after it is completed.