### PR TITLE
Fix: Avoid overflow when viewing large files

### DIFF
--- a/include/usearch/index_plugins.hpp
+++ b/include/usearch/index_plugins.hpp
@@ -396,10 +396,10 @@ inline expected_gt<metric_kind_t> metric_from_name(char const* name) {
  *  @brief Convenience function to upcast a half-precision floating point number to a single-precision one.
  */
 inline float f16_to_f32(std::uint16_t u16) noexcept {
-#if USEARCH_USE_FP16LIB
-    return fp16_ieee_to_fp32_value(u16);
-#elif USEARCH_USE_SIMSIMD
+#if USEARCH_USE_SIMSIMD
     return simsimd_f16_to_f32((simsimd_f16_t const*)&u16);
+#elif USEARCH_USE_FP16LIB
+    return fp16_ieee_to_fp32_value(u16);
 #else
 #warning "It's recommended to use SimSIMD and fp16lib for half-precision numerics"
     _Float16 f16;
@@ -412,12 +412,12 @@ inline float f16_to_f32(std::uint16_t u16) noexcept {
  *  @brief Convenience function to downcast a single-precision floating point number to a half-precision one.
  */
 inline std::uint16_t f32_to_f16(float f32) noexcept {
-#if USEARCH_USE_FP16LIB
-    return fp16_ieee_from_fp32_value(f32);
-#elif USEARCH_USE_SIMSIMD
+#if USEARCH_USE_SIMSIMD
     std::uint16_t result;
     simsimd_f32_to_f16(f32, (simsimd_f16_t*)&result);
     return result;
+#elif USEARCH_USE_FP16LIB
+    return fp16_ieee_from_fp32_value(f32);
 #else
 #warning "It's recommended to use SimSIMD and fp16lib for half-precision numerics"
     _Float16 f16 = _Float16(f32);


### PR DESCRIPTION
ClickHouse compiles Usearch
- with `USEARCH_USE_FP16LIB` on all platforms
- with `USEARCH_USE_SIMSIMD` on x86 and ARM.

I.e. on x86 and ARM, both defines are set. Previously, the code would do
the fp32 <--> fp16 conversion using fp16lib but I think it should prefer
the "homegrown" conversion routines (SimSIMD).