### PR TITLE
Make: Include submodule header files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -149,6 +149,18 @@ target_include_directories(
     ${USEARCH_TARGET_NAME} ${USEARCH_SYSTEM_INCLUDE} INTERFACE $<BUILD_INTERFACE:${USEARCH_INCLUDE_BUILD_DIR}>
                                                                $<INSTALL_INTERFACE:include>
 )
+if (USEARCH_USE_FP16LIB)
+    target_include_directories(
+        ${USEARCH_TARGET_NAME} ${USEARCH_SYSTEM_INCLUDE} INTERFACE $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/fp16/include>
+                                                                   $<INSTALL_INTERFACE:fp16/include>
+    )
+endif()
+if (USEARCH_USE_SIMSIMD)
+    target_include_directories(
+        ${USEARCH_TARGET_NAME} ${USEARCH_SYSTEM_INCLUDE} INTERFACE $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/simsimd/include>
+                                                                   $<INSTALL_INTERFACE:simsimd/include>
+    )
+endif()
 
 # Install a pkg-config file, so other tools can find this
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/cmake/pkg-config.pc.in" "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.pc")


### PR DESCRIPTION
For use in a C++ project, we configured CMakeLists.txt to fetch and build USearch.

For example, the following configuration:
```cmake
fetchcontent_declare(
  usearch
  GIT_REPOSITORY "https://github.com/unum-cloud/usearch.git"
  GIT_TAG "v2.16.5"
  GIT_SUBMODULES ...)
fetchcontent_makeavailable(usearch)
```

Then it cannot find the header file for the submodule and an error occurs.

For example, the following errors:
```
.../_deps/usearch-src/include/usearch/index_plugins.hpp:37:10: fatal error: fp16/fp16.h: No such file or directory
   37 | #include <fp16/fp16.h>
```

So we added a header file to be included in target_include_directories().