### PR TITLE
Fix Python `usearch.index.search` in non-exact similarity search

### DIFF
--- a/python/usearch/index.py
+++ b/python/usearch/index.py
@@ -1530,7 +1530,7 @@ def search(
 
     if not exact:
         index = Index(
-            dataset.shape[1],
+            ndim=dataset.shape[1],
             metric=metric,
             dtype=dataset.dtype,
         )


### PR DESCRIPTION
The  Python's`usearch.index.search` method creates an `Index` when performing a similarity search with `exact = False`. `Index` requires all its inputs to be passed by name, but the first parameter, the dimension, was not supplied like that.

This PR fixes this error by assigning a name to the first parameter of the `Index` instance, specifically `ndim`.