### PR TITLE
Improve error handling in Objective-C and Swift bindings

### DIFF
--- a/objc/include/USearchObjective.h
+++ b/objc/include/USearchObjective.h
@@ -27,6 +27,20 @@ typedef NS_ENUM(NSUInteger, USearchMetric) {
     USearchMetricSorensen
 };
 
+extern NSErrorDomain const USearchErrorDomain;
+typedef NS_ERROR_ENUM(USearchErrorDomain, USearchErrorCode) {
+    USearchUnsupportedMetric,
+    USearchAddError,
+    USearchFindError,
+    USearchAllocationError,
+    USearchRemoveError,
+    USearchRenameError,
+    USearchPathNotUTF8Encodable,
+    USearchSaveError,
+    USearchLoadError,
+    USearchViewError,
+};
+
 typedef UInt64 USearchKey;
 
 typedef bool (^USearchFilterFn)(USearchKey key);
@@ -53,7 +67,12 @@ API_AVAILABLE(ios(13.0), macos(10.15), tvos(13.0), watchos(6.0))
  * Higher connectivity improves quantization, increases memory usage, and reduces construction speed.
  * @param quantization Quantization of internal vector representations. Lower quantization means higher speed.
  */
-+ (instancetype)make:(USearchMetric)metric dimensions:(UInt32)dimensions connectivity:(UInt32)connectivity quantization:(USearchScalar)quantization NS_SWIFT_NAME(make(metric:dimensions:connectivity:quantization:));
++ (instancetype)make:(USearchMetric)metric
+          dimensions:(UInt32)dimensions
+        connectivity:(UInt32)connectivity
+        quantization:(USearchScalar)quantization
+               error:(NSError**)error __attribute__((swift_error(nonnull_error)))
+NS_SWIFT_NAME(make(metric:dimensions:connectivity:quantization:));
 
 /**
  * @brief Initializes a new index.
@@ -68,20 +87,26 @@ API_AVAILABLE(ios(13.0), macos(10.15), tvos(13.0), watchos(6.0))
           dimensions:(UInt32)dimensions
         connectivity:(UInt32)connectivity
         quantization:(USearchScalar)quantization
-               multi:(BOOL)multi NS_SWIFT_NAME(make(metric:dimensions:connectivity:quantization:multi:));
+               multi:(BOOL)multi
+               error:(NSError**)error __attribute__((swift_error(nonnull_error)))
+NS_SWIFT_NAME(make(metric:dimensions:connectivity:quantization:multi:));
 
 
 /**
  * @brief Pre-allocates space in the index for the given number of vectors.
  */
-- (void)reserve:(UInt32)count NS_SWIFT_NAME(reserve(_:));
+- (void)reserve:(UInt32)count
+          error:(NSError**)error __attribute__((swift_error(nonnull_error)))
+NS_SWIFT_NAME(reserve(_:));
 
 /**
  * @brief Adds a labeled vector to the index.
  * @param vector Single-precision vector.
  */
 - (void)addSingle:(USearchKey)key
-           vector:(Float32 const *_Nonnull)vector NS_SWIFT_NAME(addSingle(key:vector:));
+           vector:(Float32 const *_Nonnull)vector
+            error:(NSError**)error __attribute__((swift_error(nonnull_error)))
+NS_SWIFT_NAME(addSingle(key:vector:));
 
 /**
  * @brief Approximate nearest neighbors search.
@@ -94,7 +119,9 @@ API_AVAILABLE(ios(13.0), macos(10.15), tvos(13.0), watchos(6.0))
 - (UInt32)searchSingle:(Float32 const *_Nonnull)vector
                  count:(UInt32)count
                   keys:(USearchKey *_Nullable)keys
-             distances:(Float32 *_Nullable)distances NS_SWIFT_NAME(searchSingle(vector:count:keys:distances:));
+             distances:(Float32 *_Nullable)distances
+                 error:(NSError**)error __attribute__((swift_error(nonnull_error)))
+NS_SWIFT_NAME(searchSingle(vector:count:keys:distances:));
 
 /**
 * @brief Retrieves a labeled single-precision vector from the index.
@@ -104,7 +131,9 @@ API_AVAILABLE(ios(13.0), macos(10.15), tvos(13.0), watchos(6.0))
 */
 - (UInt32)getSingle:(USearchKey)key
     vector:(void *_Nonnull)vector
-    count:(UInt32)count NS_SWIFT_NAME(getSingle(key:vector:count:));
+    count:(UInt32)count
+    error:(NSError**)error __attribute__((swift_error(nonnull_error)))
+NS_SWIFT_NAME(getSingle(key:vector:count:));
 
 /**
  * @brief Approximate nearest neighbors search.
@@ -120,14 +149,18 @@ API_AVAILABLE(ios(13.0), macos(10.15), tvos(13.0), watchos(6.0))
                  count:(UInt32)count
                 filter:(USearchFilterFn)filter
                   keys:(USearchKey *_Nullable)keys
-             distances:(Float32 *_Nullable)distances NS_SWIFT_NAME(filteredSearchSingle(vector:count:filter:keys:distances:));
+             distances:(Float32 *_Nullable)distances
+                 error:(NSError**)error __attribute__((swift_error(nonnull_error)))
+NS_SWIFT_NAME(filteredSearchSingle(vector:count:filter:keys:distances:));
 
 /**
  * @brief Adds a labeled vector to the index.
  * @param vector Double-precision vector.
  */
 - (void)addDouble:(USearchKey)key
-           vector:(Float64 const *_Nonnull)vector NS_SWIFT_NAME(addDouble(key:vector:));
+           vector:(Float64 const *_Nonnull)vector
+            error:(NSError**)error __attribute__((swift_error(nonnull_error)))
+NS_SWIFT_NAME(addDouble(key:vector:));
 
 /**
  * @brief Approximate nearest neighbors search.
@@ -140,7 +173,9 @@ API_AVAILABLE(ios(13.0), macos(10.15), tvos(13.0), watchos(6.0))
 - (UInt32)searchDouble:(Float64 const *_Nonnull)vector
                  count:(UInt32)count
                   keys:(USearchKey *_Nullable)keys
-             distances:(Float32 *_Nullable)distances NS_SWIFT_NAME(searchDouble(vector:count:keys:distances:));
+             distances:(Float32 *_Nullable)distances
+                 error:(NSError**)error __attribute__((swift_error(nonnull_error)))
+NS_SWIFT_NAME(searchDouble(vector:count:keys:distances:));
 
 /**
 * @brief Retrieves a labeled double-precision vector from the index.
@@ -150,7 +185,9 @@ API_AVAILABLE(ios(13.0), macos(10.15), tvos(13.0), watchos(6.0))
 */
 - (UInt32)getDouble:(USearchKey)key
     vector:(void *_Nonnull)vector
-    count:(UInt32)count NS_SWIFT_NAME(getDouble(key:vector:count:));
+    count:(UInt32)count
+    error:(NSError**)error __attribute__((swift_error(nonnull_error)))
+NS_SWIFT_NAME(getDouble(key:vector:count:));
 
 /**
  * @brief Approximate nearest neighbors search.
@@ -166,13 +203,17 @@ API_AVAILABLE(ios(13.0), macos(10.15), tvos(13.0), watchos(6.0))
                  count:(UInt32)wanted
                 filter:(USearchFilterFn)predicate
                   keys:(USearchKey *_Nullable)keys
-             distances:(Float32 *_Nullable)distances NS_SWIFT_NAME(filteredSearchDouble(vector:count:filter:keys:distances:));
+             distances:(Float32 *_Nullable)distances
+                 error:(NSError**)error __attribute__((swift_error(nonnull_error)))
+NS_SWIFT_NAME(filteredSearchDouble(vector:count:filter:keys:distances:));
 /**
  * @brief Adds a labeled vector to the index.
  * @param vector Half-precision vector.
  */
 - (void)addHalf:(USearchKey)key
-         vector:(void const *_Nonnull)vector NS_SWIFT_NAME(addHalf(key:vector:));
+         vector:(void const *_Nonnull)vector
+          error:(NSError**)error __attribute__((swift_error(nonnull_error)))
+NS_SWIFT_NAME(addHalf(key:vector:));
 
 /**
  * @brief Approximate nearest neighbors search.
@@ -185,7 +226,9 @@ API_AVAILABLE(ios(13.0), macos(10.15), tvos(13.0), watchos(6.0))
 - (UInt32)searchHalf:(void const *_Nonnull)vector
                count:(UInt32)count
                 keys:(USearchKey *_Nullable)keys
-           distances:(Float32 *_Nullable)distances NS_SWIFT_NAME(searchHalf(vector:count:keys:distances:));
+           distances:(Float32 *_Nullable)distances
+               error:(NSError**)error __attribute__((swift_error(nonnull_error)))
+NS_SWIFT_NAME(searchHalf(vector:count:keys:distances:));
 
 /**
 * @brief Retrieves a labeled half-precision vector from the index.
@@ -194,39 +237,57 @@ API_AVAILABLE(ios(13.0), macos(10.15), tvos(13.0), watchos(6.0))
 * @return Number of vectors exported to `vector`.
 */
 - (UInt32)getHalf:(USearchKey)key
-        vector:(void *_Nonnull)vector
-        count:(UInt32)count NS_SWIFT_NAME(getHalf(key:vector:count:));
+           vector:(void *_Nonnull)vector
+            count:(UInt32)count
+            error:(NSError**)error __attribute__((swift_error(nonnull_error)))
+NS_SWIFT_NAME(getHalf(key:vector:count:));
 
-- (Boolean)contains:(USearchKey)key NS_SWIFT_NAME(contains(key:));
+- (Boolean)contains:(USearchKey)key
+              error:(NSError**)error __attribute__((swift_error(nonnull_error)))
+NS_SWIFT_NAME(contains(key:));
 
-- (UInt32)count:(USearchKey)key NS_SWIFT_NAME(count(key:));
+- (UInt32)count:(USearchKey)key
+          error:(NSError**)error __attribute__((swift_error(nonnull_error)))
+NS_SWIFT_NAME(count(key:));
 
-- (void)remove:(USearchKey)key NS_SWIFT_NAME(remove(key:));
+- (void)remove:(USearchKey)key
+         error:(NSError**)error __attribute__((swift_error(nonnull_error)))
+NS_SWIFT_NAME(remove(key:));
 
-- (void)rename:(USearchKey)key to:(USearchKey)key NS_SWIFT_NAME(rename(from:to:));
+- (void)rename:(USearchKey)key
+            to:(USearchKey)key
+         error:(NSError**)error __attribute__((swift_error(nonnull_error)))
+NS_SWIFT_NAME(rename(from:to:));
 
 
 /**
  * @brief Saves pre-constructed index to disk.
  */
-- (void)save:(NSString *)path NS_SWIFT_NAME(save(path:));
+- (void)save:(NSString *)path
+       error:(NSError**)error __attribute__((swift_error(nonnull_error)))
+NS_SWIFT_NAME(save(path:));
 
 /**
  * @brief Loads a pre-constructed index from index.
  */
-- (void)load:(NSString *)path NS_SWIFT_NAME(load(path:));
+- (void)load:(NSString *)path
+       error:(NSError**)error __attribute__((swift_error(nonnull_error)))
+NS_SWIFT_NAME(load(path:));
 
 /**
  * @brief Views a pre-constructed index from disk without loading it into RAM.
  *        Allows working with larger-than memory indexes and saving scarce
  *        memory on device in read-only workloads.
  */
-- (void)view:(NSString *)path NS_SWIFT_NAME(view(path:));
+- (void)view:(NSString *)path
+       error:(NSError**)error __attribute__((swift_error(nonnull_error)))
+NS_SWIFT_NAME(view(path:));
 
 /**
  * @brief Removes all the data from index, while preserving the settings.
  */
-- (void)clear NS_SWIFT_NAME(clear());
+- (void)clear:(NSError**)error __attribute__((swift_error(nonnull_error)))
+NS_SWIFT_NAME(clear());
 
 @end
 

--- a/swift/Index+Sugar.swift
+++ b/swift/Index+Sugar.swift
@@ -18,9 +18,9 @@ extension USearchIndex {
     /// - Parameter key: Unique identifier for that object.
     /// - Parameter vector: Single-precision vector.
     /// - Throws: If runs out of memory.
-    public func add(key: USearchKey, vector: ArraySlice<Float32>) {
-        vector.withContiguousStorageIfAvailable {
-            addSingle(key: key, vector: $0.baseAddress!)
+    public func add(key: USearchKey, vector: ArraySlice<Float32>) throws {
+        try vector.withContiguousStorageIfAvailable {
+            try addSingle(key: key, vector: $0.baseAddress!)
         }
     }
 
@@ -28,8 +28,8 @@ extension USearchIndex {
     /// - Parameter key: Unique identifier for that object.
     /// - Parameter vector: Single-precision vector.
     /// - Throws: If runs out of memory.
-    public func add(key: USearchKey, vector: [Float32]) {
-        add(key: key, vector: vector[...])
+    public func add(key: USearchKey, vector: [Float32]) throws {
+        try add(key: key, vector: vector[...])
     }
 
     /// Approximate nearest neighbors search.
@@ -37,11 +37,11 @@ extension USearchIndex {
     /// - Parameter count: Upper limit on the number of matches to retrieve.
     /// - Returns: Labels and distances to closest approximate matches in decreasing similarity order.
     /// - Throws: If runs out of memory.
-    public func search(vector: ArraySlice<Float32>, count: Int) -> ([Key], [Float]) {
+    public func search(vector: ArraySlice<Float32>, count: Int) throws -> ([Key], [Float]) {
         var matches: [Key] = Array(repeating: 0, count: count)
         var distances: [Float] = Array(repeating: 0, count: count)
-        let results = vector.withContiguousStorageIfAvailable {
-            searchSingle(vector: $0.baseAddress!, count: CUnsignedInt(count), keys: &matches, distances: &distances)
+        let results = try vector.withContiguousStorageIfAvailable {
+            try searchSingle(vector: $0.baseAddress!, count: CUnsignedInt(count), keys: &matches, distances: &distances)
         }
         matches.removeLast(count - Int(results!))
         distances.removeLast(count - Int(results!))
@@ -53,8 +53,8 @@ extension USearchIndex {
     /// - Parameter count: Upper limit on the number of matches to retrieve.
     /// - Returns: Labels and distances to closest approximate matches in decreasing similarity order.
     /// - Throws: If runs out of memory.
-    public func search(vector: [Float32], count: Int) -> ([Key], [Float]) {
-        return search(vector: vector[...], count: count)
+    public func search(vector: [Float32], count: Int) throws -> ([Key], [Float]) {
+        return try search(vector: vector[...], count: count)
     }
 
     /// Retrieve vectors for a given key.
@@ -62,11 +62,11 @@ extension USearchIndex {
     /// - Parameter count: For multi-indexes, Number of vectors to retrieve. Defaults to 1.
     /// - Returns: Two-dimensional array of Single-precision vectors.
     /// - Throws: If runs out of memory.
-    public func get(key: USearchKey, count: Int = 1) -> [[Float]]? {
+    public func get(key: USearchKey, count: Int = 1) throws -> [[Float]]? {
         var vector: [Float] = Array(repeating: 0.0, count: Int(self.dimensions) * count)
-        let returnedCount = vector.withContiguousMutableStorageIfAvailable { buf in
+        let returnedCount = try vector.withContiguousMutableStorageIfAvailable { buf in
             guard let baseAddress = buf.baseAddress else { return UInt32(0) }
-            return getSingle(
+            return try getSingle(
                 key: key,
                 vector: baseAddress,
                 count: CUnsignedInt(count)
@@ -86,9 +86,9 @@ extension USearchIndex {
     /// - Parameter key: Unique identifier for that object.
     /// - Parameter vector: Double-precision vector.
     /// - Throws: If runs out of memory.
-    public func add(key: Key, vector: ArraySlice<Float64>) {
-        vector.withContiguousStorageIfAvailable {
-            addDouble(key: key, vector: $0.baseAddress!)
+    public func add(key: Key, vector: ArraySlice<Float64>) throws {
+        try vector.withContiguousStorageIfAvailable {
+            try addDouble(key: key, vector: $0.baseAddress!)
         }
     }
 
@@ -96,8 +96,8 @@ extension USearchIndex {
     /// - Parameter key: Unique identifier for that object.
     /// - Parameter vector: Double-precision vector.
     /// - Throws: If runs out of memory.
-    public func add(key: Key, vector: [Float64]) {
-        add(key: key, vector: vector[...])
+    public func add(key: Key, vector: [Float64]) throws {
+        try add(key: key, vector: vector[...])
     }
 
     /// Approximate nearest neighbors search.
@@ -105,11 +105,11 @@ extension USearchIndex {
     /// - Parameter count: Upper limit on the number of matches to retrieve.
     /// - Returns: Labels and distances to closest approximate matches in decreasing similarity order.
     /// - Throws: If runs out of memory.
-    public func search(vector: ArraySlice<Float64>, count: Int) -> ([Key], [Float]) {
+    public func search(vector: ArraySlice<Float64>, count: Int) throws -> ([Key], [Float]) {
         var matches: [Key] = Array(repeating: 0, count: count)
         var distances: [Float] = Array(repeating: 0, count: count)
-        let results = vector.withContiguousStorageIfAvailable {
-            searchDouble(vector: $0.baseAddress!, count: CUnsignedInt(count), keys: &matches, distances: &distances)
+        let results = try vector.withContiguousStorageIfAvailable {
+            try searchDouble(vector: $0.baseAddress!, count: CUnsignedInt(count), keys: &matches, distances: &distances)
         }
         matches.removeLast(count - Int(results!))
         distances.removeLast(count - Int(results!))
@@ -121,8 +121,8 @@ extension USearchIndex {
     /// - Parameter count: Upper limit on the number of matches to retrieve.
     /// - Returns: Labels and distances to closest approximate matches in decreasing similarity order.
     /// - Throws: If runs out of memory.
-    public func search(vector: [Float64], count: Int) -> ([Key], [Float]) {
-        search(vector: vector[...], count: count)
+    public func search(vector: [Float64], count: Int) throws -> ([Key], [Float]) {
+        try search(vector: vector[...], count: count)
     }
 
     /// Retrieve vectors for a given key.
@@ -130,11 +130,11 @@ extension USearchIndex {
     /// - Parameter count: For multi-indexes, Number of vectors to retrieve. Defaults to 1.
     /// - Returns: Two-dimensional array of Double-precision vectors.
     /// - Throws: If runs out of memory.
-    public func get(key: USearchKey, count: Int = 1) -> [[Float64]]? {
+    public func get(key: USearchKey, count: Int = 1) throws -> [[Float64]]? {
         var vector: [Float64] = Array(repeating: 0.0, count: Int(self.dimensions) * count)
-        let count = vector.withContiguousMutableStorageIfAvailable { buf in
+        let count = try vector.withContiguousMutableStorageIfAvailable { buf in
             guard let baseAddress = buf.baseAddress else { return UInt32(0) }
-            return getDouble(
+            return try getDouble(
                 key: key,
                 vector: baseAddress,
                 count: CUnsignedInt(count)
@@ -156,12 +156,12 @@ extension USearchIndex {
     /// - Parameter filter: Closure used to determine whether to skip a key in the results.
     /// - Returns: Labels and distances to closest approximate matches in decreasing similarity order.
     /// - Throws: If runs out of memory.
-    public func filteredSearch(vector: ArraySlice<Float32>, count: Int, filter: @escaping FilterFn) -> ([Key], [Float])
+    public func filteredSearch(vector: ArraySlice<Float32>, count: Int, filter: @escaping FilterFn) throws -> ([Key], [Float])
     {
         var matches: [Key] = Array(repeating: 0, count: count)
         var distances: [Float] = Array(repeating: 0, count: count)
-        let results = vector.withContiguousStorageIfAvailable {
-            filteredSearchSingle(
+        let results = try vector.withContiguousStorageIfAvailable {
+            try filteredSearchSingle(
                 vector: $0.baseAddress!,
                 count:
                     CUnsignedInt(count),
@@ -181,8 +181,8 @@ extension USearchIndex {
     /// - Parameter filter: Closure used to determine whether to skip a key in the results.
     /// - Returns: Labels and distances to closest approximate matches in decreasing similarity order.
     /// - Throws: If runs out of memory.
-    public func filteredSearch(vector: [Float32], count: Int, filter: @escaping FilterFn) -> ([Key], [Float]) {
-        filteredSearch(vector: vector[...], count: count, filter: filter)
+    public func filteredSearch(vector: [Float32], count: Int, filter: @escaping FilterFn) throws -> ([Key], [Float]) {
+        try filteredSearch(vector: vector[...], count: count, filter: filter)
     }
 
     /// Approximate nearest neighbors search.
@@ -191,12 +191,12 @@ extension USearchIndex {
     /// - Parameter filter: Closure used to determine whether to skip a key in the results.
     /// - Returns: Labels and distances to closest approximate matches in decreasing similarity order.
     /// - Throws: If runs out of memory.
-    public func filteredSearch(vector: ArraySlice<Float64>, count: Int, filter: @escaping FilterFn) -> ([Key], [Float])
+    public func filteredSearch(vector: ArraySlice<Float64>, count: Int, filter: @escaping FilterFn) throws -> ([Key], [Float])
     {
         var matches: [Key] = Array(repeating: 0, count: count)
         var distances: [Float] = Array(repeating: 0, count: count)
-        let results = vector.withContiguousStorageIfAvailable {
-            filteredSearchDouble(
+        let results = try vector.withContiguousStorageIfAvailable {
+            try filteredSearchDouble(
                 vector: $0.baseAddress!,
                 count:
                     CUnsignedInt(count),
@@ -216,8 +216,8 @@ extension USearchIndex {
     /// - Parameter filter: Closure used to determine whether to skip a key in the results.
     /// - Returns: Labels and distances to closest approximate matches in decreasing similarity order.
     /// - Throws: If runs out of memory.
-    public func filteredSearch(vector: [Float64], count: Int, filter: @escaping FilterFn) -> ([Key], [Float]) {
-        filteredSearch(vector: vector[...], count: count, filter: filter)
+    public func filteredSearch(vector: [Float64], count: Int, filter: @escaping FilterFn) throws -> ([Key], [Float]) {
+        try filteredSearch(vector: vector[...], count: count, filter: filter)
     }
 
     #if arch(arm64)
@@ -227,9 +227,9 @@ extension USearchIndex {
         /// - Parameter vector: Half-precision vector.
         /// - Throws: If runs out of memory.
         @available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)
-        public func add(key: Key, vector: ArraySlice<Float16>) {
-            vector.withContiguousStorageIfAvailable { buffer in
-                addHalf(key: key, vector: buffer.baseAddress!)
+        public func add(key: Key, vector: ArraySlice<Float16>) throws {
+            try vector.withContiguousStorageIfAvailable { buffer in
+                try addHalf(key: key, vector: buffer.baseAddress!)
             }
         }
 
@@ -238,8 +238,8 @@ extension USearchIndex {
         /// - Parameter vector: Half-precision vector.
         /// - Throws: If runs out of memory.
         @available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)
-        public func add(key: Key, vector: [Float16]) {
-            add(key: key, vector: vector[...])
+        public func add(key: Key, vector: [Float16]) throws {
+            try add(key: key, vector: vector[...])
         }
 
         /// Approximate nearest neighbors search.
@@ -248,11 +248,11 @@ extension USearchIndex {
         /// - Returns: Labels and distances to closest approximate matches in decreasing similarity order.
         /// - Throws: If runs out of memory.
         @available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)
-        public func search(vector: ArraySlice<Float16>, count: Int) -> ([Key], [Float]) {
+        public func search(vector: ArraySlice<Float16>, count: Int) throws -> ([Key], [Float]) {
             var matches: [Key] = Array(repeating: 0, count: count)
             var distances: [Float] = Array(repeating: 0, count: count)
-            let results = vector.withContiguousStorageIfAvailable {
-                searchHalf(vector: $0.baseAddress!, count: CUnsignedInt(count), keys: &matches, distances: &distances)
+            let results = try vector.withContiguousStorageIfAvailable {
+                try searchHalf(vector: $0.baseAddress!, count: CUnsignedInt(count), keys: &matches, distances: &distances)
             }
             matches.removeLast(count - Int(results!))
             distances.removeLast(count - Int(results!))
@@ -265,8 +265,8 @@ extension USearchIndex {
         /// - Returns: Labels and distances to closest approximate matches in decreasing similarity order.
         /// - Throws: If runs out of memory.
         @available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)
-        public func search(vector: [Float16], count: Int) -> ([Key], [Float]) {
-            search(vector: vector[...], count: count)
+        public func search(vector: [Float16], count: Int) throws -> ([Key], [Float]) {
+            try search(vector: vector[...], count: count)
         }
 
         /// Retrieve vectors for a given key.
@@ -275,11 +275,11 @@ extension USearchIndex {
         /// - Returns: Two-dimensional array of Half-precision vectors.
         /// - Throws: If runs out of memory.
         @available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)
-        public func get(key: USearchKey, count: Int = 1) -> [[Float16]]? {
+        public func get(key: USearchKey, count: Int = 1) throws -> [[Float16]]? {
             var vector: [Float16] = Array(repeating: 0.0, count: Int(self.dimensions) * count)
-            let count = vector.withContiguousMutableStorageIfAvailable { buf in
+            let count = try vector.withContiguousMutableStorageIfAvailable { buf in
                 guard let baseAddress = buf.baseAddress else { return UInt32(0) }
-                return getSingle(
+                return try getSingle(
                     key: key,
                     vector: baseAddress,
                     count: CUnsignedInt(count)

--- a/swift/Test.swift
+++ b/swift/Test.swift
@@ -1,5 +1,5 @@
 //
-//  File.swift
+//  Test.swift
 //
 //
 //  Created by Ash Vardanian on 5/11/23.
@@ -12,7 +12,7 @@ import XCTest
 @available(iOS 13, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
 class Test: XCTestCase {
     func testUnit() throws {
-        let index = USearchIndex.make(
+        let index = try USearchIndex.make(
             metric: USearchMetric.l2sq,
             dimensions: 4,
             connectivity: 8,
@@ -20,37 +20,37 @@ class Test: XCTestCase {
         )
         let vectorA: [Float32] = [0.3, 0.5, 1.2, 1.4]
         let vectorB: [Float32] = [0.4, 0.2, 1.2, 1.1]
-        index.reserve(2)
+        try index.reserve(2)
 
         // Adding a slice
-        index.add(key: 42, vector: vectorA[...])
+        try index.add(key: 42, vector: vectorA[...])
 
         // Adding a vector
-        index.add(key: 43, vector: vectorB)
+        try index.add(key: 43, vector: vectorB)
 
-        let results = index.search(vector: vectorA, count: 10)
+        let results = try index.search(vector: vectorA, count: 10)
         XCTAssertEqual(results.0[0], 42)
 
-        let fetched: [[Float]]? = index.get(key: 42)
+        let fetched: [[Float]]? = try index.get(key: 42)
         XCTAssertEqual(fetched?[0], vectorA)
 
-        XCTAssertTrue(index.contains(key: 42))
-        XCTAssertEqual(index.count(key: 42), 1)
-        XCTAssertEqual(index.count(key: 49), 0)
-        index.rename(from: 42, to: 49)
-        XCTAssertEqual(index.count(key: 49), 1)
+        XCTAssertTrue(try index.contains(key: 42))
+        XCTAssertEqual(try index.count(key: 42), 1)
+        XCTAssertEqual(try index.count(key: 49), 0)
+        try index.rename(from: 42, to: 49)
+        XCTAssertEqual(try index.count(key: 49), 1)
 
-        let refetched: [[Float]]? = index.get(key: 49)
+        let refetched: [[Float]]? = try index.get(key: 49)
         XCTAssertEqual(refetched?[0], vectorA)
-        let stale: [[Float]]? = index.get(key: 42)
+        let stale: [[Float]]? = try index.get(key: 42)
         XCTAssertNil(stale)
 
-        index.remove(key: 49)
-        XCTAssertEqual(index.count(key: 49), 0)
+        try index.remove(key: 49)
+        XCTAssertEqual(try index.count(key: 49), 0)
     }
 
     func testUnitMulti() throws {
-        let index = USearchIndex.make(
+        let index = try USearchIndex.make(
             metric: USearchMetric.l2sq,
             dimensions: 4,
             connectivity: 8,
@@ -59,85 +59,85 @@ class Test: XCTestCase {
         )
         let vectorA: [Float32] = [0.3, 0.5, 1.2, 1.4]
         let vectorB: [Float32] = [0.4, 0.2, 1.2, 1.1]
-        index.reserve(2)
+        try index.reserve(2)
 
         // Adding a slice
-        index.add(key: 42, vector: vectorA[...])
+        try index.add(key: 42, vector: vectorA[...])
 
         // Adding a vector
-        index.add(key: 42, vector: vectorB)
+        try index.add(key: 42, vector: vectorB)
 
-        let results = index.search(vector: vectorA, count: 10)
+        let results = try index.search(vector: vectorA, count: 10)
         XCTAssertEqual(results.0[0], 42)
 
-        let fetched: [[Float]]? = index.get(key: 42, count: 2)
+        let fetched: [[Float]]? = try index.get(key: 42, count: 2)
         XCTAssertEqual(fetched?.contains(vectorA), true)
         XCTAssertEqual(fetched?.contains(vectorB), true)
 
-        XCTAssertTrue(index.contains(key: 42))
-        XCTAssertEqual(index.count(key: 42), 2)
-        XCTAssertEqual(index.count(key: 49), 0)
-        index.rename(from: 42, to: 49)
-        XCTAssertEqual(index.count(key: 49), 2)
+        XCTAssertTrue(try index.contains(key: 42))
+        XCTAssertEqual(try index.count(key: 42), 2)
+        XCTAssertEqual(try index.count(key: 49), 0)
+        try index.rename(from: 42, to: 49)
+        XCTAssertEqual(try index.count(key: 49), 2)
 
-        let refetched: [[Float]]? = index.get(key: 49, count: 2)
+        let refetched: [[Float]]? = try index.get(key: 49, count: 2)
         XCTAssertEqual(refetched?.contains(vectorA), true)
         XCTAssertEqual(refetched?.contains(vectorB), true)
-        let stale: [[Float]]? = index.get(key: 42)
+        let stale: [[Float]]? = try index.get(key: 42)
         XCTAssertNil(stale)
 
-        index.remove(key: 49)
-        XCTAssertEqual(index.count(key: 49), 0)
+        try index.remove(key: 49)
+        XCTAssertEqual(try index.count(key: 49), 0)
     }
 
-    func testIssue399() {
-        let index = USearchIndex.make(
+    func testIssue399() throws {
+        let index = try USearchIndex.make(
             metric: USearchMetric.l2sq,
             dimensions: 1,
             connectivity: 8,
             quantization: USearchScalar.F32
         )
-        index.reserve(3)
+        try index.reserve(3)
 
         // add 3 entries then ensure all 3 are returned
-        index.add(key: 1, vector: [1.1])
-        index.add(key: 2, vector: [2.1])
-        index.add(key: 3, vector: [3.1])
+        try index.add(key: 1, vector: [1.1])
+        try index.add(key: 2, vector: [2.1])
+        try index.add(key: 3, vector: [3.1])
         XCTAssertEqual(index.count, 3)
-        XCTAssertEqual(index.search(vector: [1.0], count: 3).0, [1, 2, 3])  // works 😎
+        XCTAssertEqual(try index.search(vector: [1.0], count: 3).0, [1, 2, 3])  // works 😎
 
         // replace second-added entry then ensure all 3 are still returned
-        index.remove(key: 2)
-        index.add(key: 2, vector: [2.2])
+        try index.remove(key: 2)
+        try index.add(key: 2, vector: [2.2])
         XCTAssertEqual(index.count, 3)
-        XCTAssertEqual(index.search(vector: [1.0], count: 3).0, [1, 2, 3])  // works 😎
+        XCTAssertEqual(try index.search(vector: [1.0], count: 3).0, [1, 2, 3])  // works 😎
 
         // replace first-added entry then ensure all 3 are still returned
-        index.remove(key: 1)
-        index.add(key: 1, vector: [1.2])
-        let afterReplacingInitial = index.search(vector: [1.0], count: 3).0
+        try index.remove(key: 1)
+        try index.add(key: 1, vector: [1.2])
+        let afterReplacingInitial = try index.search(vector: [1.0], count: 3).0
         XCTAssertEqual(index.count, 3)
         XCTAssertEqual(afterReplacingInitial, [1, 2, 3])  // v2.11.7 fails with "[1] != [1, 2, 3]" 😨
     }
 
-    func testFilteredSearchSingle() {
-        let index = USearchIndex.make(
+    func testFilteredSearchSingle() throws {
+        let index = try USearchIndex.make(
             metric: USearchMetric.l2sq,
             dimensions: 1,
             connectivity: 8,
             quantization: USearchScalar.F32
         )
-        index.reserve(3)
+        try index.reserve(3)
 
         // add 3 entries
-        index.add(key: 1, vector: [1.1])
-        index.add(key: 2, vector: [2.1])
-        index.add(key: 3, vector: [3.1])
+        try index.add(key: 1, vector: [1.1])
+        try index.add(key: 2, vector: [2.1])
+        try index.add(key: 3, vector: [3.1])
         XCTAssertEqual(index.count, 3)
 
         // filter which accepts all keys:
         XCTAssertEqual(
-            index.filteredSearch(vector: [1.0], count: 3) {
+            try index.filteredSearch(vector: [1.0], count: 3) {
                 key in true
             }.0,
             [1, 2, 3]
@@ -145,7 +145,7 @@ class Test: XCTestCase {
 
         // filter which rejects all keys:
         XCTAssertEqual(
-            index.filteredSearch(vector: [1.0], count: 3) {
+            try index.filteredSearch(vector: [1.0], count: 3) {
                 key in false
             }.0,
             []
@@ -154,7 +154,7 @@ class Test: XCTestCase {
         // filter function accepts a set of keys passed in through a capture.
         let acceptedKeys: [USearchKey] = [1, 2]
         XCTAssertEqual(
-            index.filteredSearch(vector: [1.0], count: 3) {
+            try index.filteredSearch(vector: [1.0], count: 3) {
                 key in acceptedKeys.contains(key)
             }.0,
             acceptedKeys
@@ -163,37 +163,37 @@ class Test: XCTestCase {
         // filter function accepts a set of keys passed in through a capture,
         // and also adheres to the count.
         XCTAssertEqual(
-            index.filteredSearch(vector: [1.0], count: 1) {
+            try index.filteredSearch(vector: [1.0], count: 1) {
                 key in key > 1
             }.0,
             [2]
         )  // works 😎
         XCTAssertEqual(
-            index.filteredSearch(vector: [1.0], count: 2) {
+            try index.filteredSearch(vector: [1.0], count: 2) {
                 key in key > 1
             }.0,
             [2, 3]
         )  // works 😎
     }
 
-    func testFilteredSearchDouble() {
-        let index = USearchIndex.make(
+    func testFilteredSearchDouble() throws {
+        let index = try USearchIndex.make(
             metric: USearchMetric.l2sq,
             dimensions: 1,
             connectivity: 8,
             quantization: USearchScalar.F64
         )
-        index.reserve(3)
+        try index.reserve(3)
 
         // add 3 entries
-        index.add(key: 1, vector: [Float64(1.1)])
-        index.add(key: 2, vector: [Float64(2.1)])
-        index.add(key: 3, vector: [Float64(3.1)])
+        try index.add(key: 1, vector: [Float64(1.1)])
+        try index.add(key: 2, vector: [Float64(2.1)])
+        try index.add(key: 3, vector: [Float64(3.1)])
         XCTAssertEqual(index.count, 3)
 
         // filter which accepts all keys:
         XCTAssertEqual(
-            index.filteredSearch(vector: [Float64(1.0)], count: 3) {
+            try index.filteredSearch(vector: [Float64(1.0)], count: 3) {
                 key in true
             }.0,
             [1, 2, 3]
@@ -201,7 +201,7 @@ class Test: XCTestCase {
 
         // filter which rejects all keys:
         XCTAssertEqual(
-            index.filteredSearch(vector: [Float64(1.0)], count: 3) {
+            try index.filteredSearch(vector: [Float64(1.0)], count: 3) {
                 key in false
             }.0,
             []
@@ -210,7 +210,7 @@ class Test: XCTestCase {
         // filter function accepts a set of keys passed in through a capture.
         let acceptedKeys: [USearchKey] = [1, 2]
         XCTAssertEqual(
-            index.filteredSearch(vector: [Float64(1.0)], count: 3) {
+            try index.filteredSearch(vector: [Float64(1.0)], count: 3) {
                 key in acceptedKeys.contains(key)
             }.0,
             acceptedKeys
@@ -219,13 +219,13 @@ class Test: XCTestCase {
         // filter function accepts a set of keys passed in through a capture,
         // and also respects the count.
         XCTAssertEqual(
-            index.filteredSearch(vector: [Float64(1.0)], count: 1) {
+            try index.filteredSearch(vector: [Float64(1.0)], count: 1) {
                 key in key > 1
             }.0,
             [2]
         )  // works 😎
         XCTAssertEqual(
-            index.filteredSearch(vector: [Float64(1.0)], count: 2) {
+            try index.filteredSearch(vector: [Float64(1.0)], count: 2) {
                 key in key > 1
             }.0,
             [2, 3]

--- a/swift/Test.swift
+++ b/swift/Test.swift
@@ -29,24 +29,24 @@ class Test: XCTestCase {
         index.add(key: 43, vector: vectorB)
 
         let results = index.search(vector: vectorA, count: 10)
-        assert(results.0[0] == 42)
+        XCTAssertEqual(results.0[0], 42)
 
         let fetched: [[Float]]? = index.get(key: 42)
-        assert(fetched?[0] == vectorA)
+        XCTAssertEqual(fetched?[0], vectorA)
 
-        assert(index.contains(key: 42))
-        assert(index.count(key: 42) == 1)
-        assert(index.count(key: 49) == 0)
+        XCTAssertTrue(index.contains(key: 42))
+        XCTAssertEqual(index.count(key: 42), 1)
+        XCTAssertEqual(index.count(key: 49), 0)
         index.rename(from: 42, to: 49)
-        assert(index.count(key: 49) == 1)
+        XCTAssertEqual(index.count(key: 49), 1)
 
         let refetched: [[Float]]? = index.get(key: 49)
-        assert(refetched?[0] == vectorA)
+        XCTAssertEqual(refetched?[0], vectorA)
         let stale: [[Float]]? = index.get(key: 42)
-        assert(stale == nil)
+        XCTAssertNil(stale)
 
         index.remove(key: 49)
-        assert(index.count(key: 49) == 0)
+        XCTAssertEqual(index.count(key: 49), 0)
     }
 
     func testUnitMulti() throws {
@@ -68,26 +68,26 @@ class Test: XCTestCase {
         index.add(key: 42, vector: vectorB)
 
         let results = index.search(vector: vectorA, count: 10)
-        assert(results.0[0] == 42)
+        XCTAssertEqual(results.0[0], 42)
 
         let fetched: [[Float]]? = index.get(key: 42, count: 2)
-        assert(fetched?.contains(vectorA) == true)
-        assert(fetched?.contains(vectorB) == true)
+        XCTAssertEqual(fetched?.contains(vectorA), true)
+        XCTAssertEqual(fetched?.contains(vectorB), true)
 
-        assert(index.contains(key: 42))
-        assert(index.count(key: 42) == 2)
-        assert(index.count(key: 49) == 0)
+        XCTAssertTrue(index.contains(key: 42))
+        XCTAssertEqual(index.count(key: 42), 2)
+        XCTAssertEqual(index.count(key: 49), 0)
         index.rename(from: 42, to: 49)
-        assert(index.count(key: 49) == 2)
+        XCTAssertEqual(index.count(key: 49), 2)
 
         let refetched: [[Float]]? = index.get(key: 49, count: 2)
-        assert(refetched?.contains(vectorA) == true)
-        assert(refetched?.contains(vectorB) == true)
+        XCTAssertEqual(refetched?.contains(vectorA), true)
+        XCTAssertEqual(refetched?.contains(vectorB), true)
         let stale: [[Float]]? = index.get(key: 42)
-        assert(stale == nil)
+        XCTAssertNil(stale)
 
         index.remove(key: 49)
-        assert(index.count(key: 49) == 0)
+        XCTAssertEqual(index.count(key: 49), 0)
     }
 
     func testIssue399() {


### PR DESCRIPTION
This is a **breaking change** to the Objective-C and Swift bindings.

**Why?** – Because `NSException` which is currently used, is designed for unrecoverable runtime exceptions, not control flow. In Objective-C this is awkward to handle, and in Swift it's impossible to catch.

This change switches from throwing `NSException`s to returning `NSError`s, in the style recommended for handling cross-language errors in the Apple documentation: https://developer.apple.com/documentation/swift/handling-cocoa-errors-in-swift. This is worth a breaking change in order to accurately represent the possibilities of errors in the API contracts in both languages.

The Objective-C APIs include an `(NSError**)error` argument, allowing callsites to pass an empty error pointer to be populated for error handling. This is a very common pattern in Objective-C APIs.

```objc
NSError *error = nil;
[index add:foo error:&error];
if (error != nil) {
    // handle error
}
```

In Swift, this is translated to a throwing error in the normal Swift way:

```swift
try {
    index.add(foo)
} catch {
    println("\(error)")
}
```

Additionally, the error enum is bridged to Swift so that errors can be disambiguated.

Fixes: #554 