### PR TITLE
Bug: segfault when run usearch_search() concurrently with golang #564

### DIFF
--- a/include/usearch/index_dense.hpp
+++ b/include/usearch/index_dense.hpp
@@ -1971,7 +1971,14 @@ class index_dense_gt {
 
         available_threads_mutex_.lock();
         usearch_assert_m(available_threads_.size(), "No available threads to lock");
-        available_threads_.try_pop(thread_id);
+        while (true) {
+            if (available_threads_.try_pop(thread_id)) {
+                break;
+        }
+            available_threads_mutex_.unlock();
+            usleep(10);
+            available_threads_mutex_.lock();
+        }
         available_threads_mutex_.unlock();
         return {*this, thread_id, true};
     }

--- a/include/usearch/index_dense.hpp
+++ b/include/usearch/index_dense.hpp
@@ -1974,7 +1974,7 @@ class index_dense_gt {
         while (true) {
             if (available_threads_.try_pop(thread_id)) {
                 break;
-        }
+            }
             available_threads_mutex_.unlock();
             usleep(10);
             available_threads_mutex_.lock();


### PR DESCRIPTION
 fixed issue Bug: segfault when run usearch_search() concurrently with golang #564

code didn't check try_pop return false and continue to proceed and segfault as result.

loop try_pop until success.