### PR TITLE
Swift Linux Support

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -189,6 +189,18 @@
             ],
             "cwd": "${workspaceFolder}/csharp",
             "stopAtEntry": false
+        },
+        {
+            "type": "lldb",
+            "name": "Debug Swift",
+            "request": "launch",
+            "sourceLanguages": [
+                "swift"
+            ],
+            "args": [],
+            "cwd": "${workspaceFolder}",
+            "program": "${workspaceFolder}/.build/debug/USearchTestsSwift",
+            "preLaunchTask": "Swift Build"
         }
     ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -66,6 +66,17 @@
                     ]
                 }
             }
+        },
+        {
+            "label": "Swift Build",
+            "type": "swift",
+            "args": [
+                "build",
+                "--build-tests",
+            ],
+            "env": {},
+            "cwd": "${workspaceFolder}",
+            "group": "build"
         }
     ]
 }

--- a/c/lib.cpp
+++ b/c/lib.cpp
@@ -493,4 +493,9 @@ USEARCH_EXPORT void usearch_exact_search(                             //
             query_distances[i] = static_cast<usearch_distance_t>(query_result[i].distance);
     }
 }
+
+USEARCH_EXPORT void usearch_clear(usearch_index_t index, usearch_error_t* error) {
+    USEARCH_ASSERT(index && error && "Missing arguments");
+    reinterpret_cast<index_dense_t*>(index)->clear();
+}
 }

--- a/c/module.modulemap
+++ b/c/module.modulemap
@@ -1,7 +1,4 @@
-module usearch_c {
+module USearchC {
     header "usearch.h"
-
-    requires cplusplus
-
     export *
 }

--- a/c/module.modulemap
+++ b/c/module.modulemap
@@ -1,0 +1,7 @@
+module usearch_c {
+    header "usearch.h"
+
+    requires cplusplus
+
+    export *
+}

--- a/c/usearch.h
+++ b/c/usearch.h
@@ -472,6 +472,14 @@ USEARCH_EXPORT void usearch_exact_search(                            //
     usearch_distance_t* distances, size_t distances_stride,          //
     usearch_error_t* error);
 
+/**
+ * @brief Erases all the vectors from the index.
+ *  @param[inout] index The handle to the USearch index to be modified.
+ *  @param[out] error Pointer to a string where the error message will be stored, if an error occurs.
+ */
+USEARCH_EXPORT void usearch_clear(usearch_index_t index,
+                                  usearch_error_t* error);
+
 #ifdef __cplusplus
 }
 #endif

--- a/c/usearch.h
+++ b/c/usearch.h
@@ -1,6 +1,10 @@
 #ifndef UNUM_USEARCH_H
 #define UNUM_USEARCH_H
 
+#include <stdbool.h> // `bool`
+#include <stddef.h>  // `size_t`
+#include <stdint.h>  // `uint64_t`
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -12,10 +16,6 @@ extern "C" {
 #define USEARCH_EXPORT
 #endif
 #endif
-
-#include <stdbool.h> // `bool`
-#include <stddef.h>  // `size_t`
-#include <stdint.h>  // `uint64_t`
 
 USEARCH_EXPORT typedef void* usearch_index_t;
 USEARCH_EXPORT typedef uint64_t usearch_key_t;

--- a/swift/Index+Sugar.swift
+++ b/swift/Index+Sugar.swift
@@ -18,9 +18,9 @@ extension USearchIndex {
     /// - Parameter key: Unique identifier for that object.
     /// - Parameter vector: Single-precision vector.
     /// - Throws: If runs out of memory.
-    public func add(key: USearchKey, vector: ArraySlice<Float32>) {
-        vector.withContiguousStorageIfAvailable {
-            addSingle(key: key, vector: $0.baseAddress!)
+    public func add(key: USearchKey, vector: ArraySlice<Float32>) throws {
+        try vector.withContiguousStorageIfAvailable {
+            try addSingle(key: key, vector: $0.baseAddress!)
         }
     }
 
@@ -28,8 +28,8 @@ extension USearchIndex {
     /// - Parameter key: Unique identifier for that object.
     /// - Parameter vector: Single-precision vector.
     /// - Throws: If runs out of memory.
-    public func add(key: USearchKey, vector: [Float32]) {
-        add(key: key, vector: vector[...])
+    public func add(key: USearchKey, vector: [Float32]) throws {
+        try add(key: key, vector: vector[...])
     }
 
     /// Approximate nearest neighbors search.
@@ -37,11 +37,11 @@ extension USearchIndex {
     /// - Parameter count: Upper limit on the number of matches to retrieve.
     /// - Returns: Labels and distances to closest approximate matches in decreasing similarity order.
     /// - Throws: If runs out of memory.
-    public func search(vector: ArraySlice<Float32>, count: Int) -> ([Key], [Float]) {
+    public func search(vector: ArraySlice<Float32>, count: Int) throws -> ([Key], [Float]) {
         var matches: [Key] = Array(repeating: 0, count: count)
         var distances: [Float] = Array(repeating: 0, count: count)
-        let results = vector.withContiguousStorageIfAvailable {
-            searchSingle(vector: $0.baseAddress!, count: CUnsignedInt(count), keys: &matches, distances: &distances)
+        let results = try vector.withContiguousStorageIfAvailable {
+            try searchSingle(vector: $0.baseAddress!, count: CUnsignedInt(count), keys: &matches, distances: &distances)
         }
         matches.removeLast(count - Int(results!))
         distances.removeLast(count - Int(results!))
@@ -53,8 +53,8 @@ extension USearchIndex {
     /// - Parameter count: Upper limit on the number of matches to retrieve.
     /// - Returns: Labels and distances to closest approximate matches in decreasing similarity order.
     /// - Throws: If runs out of memory.
-    public func search(vector: [Float32], count: Int) -> ([Key], [Float]) {
-        return search(vector: vector[...], count: count)
+    public func search(vector: [Float32], count: Int) throws -> ([Key], [Float]) {
+        return try search(vector: vector[...], count: count)
     }
 
     /// Retrieve vectors for a given key.
@@ -62,11 +62,11 @@ extension USearchIndex {
     /// - Parameter count: For multi-indexes, Number of vectors to retrieve. Defaults to 1.
     /// - Returns: Two-dimensional array of Single-precision vectors.
     /// - Throws: If runs out of memory.
-    public func get(key: USearchKey, count: Int = 1) -> [[Float]]? {
+    public func get(key: USearchKey, count: Int = 1) throws -> [[Float]]? {
         var vector: [Float] = Array(repeating: 0.0, count: Int(self.dimensions) * count)
-        let returnedCount = vector.withContiguousMutableStorageIfAvailable { buf in
+        let returnedCount = try vector.withContiguousMutableStorageIfAvailable { buf in
             guard let baseAddress = buf.baseAddress else { return UInt32(0) }
-            return getSingle(
+            return try getSingle(
                 key: key,
                 vector: baseAddress,
                 count: CUnsignedInt(count)
@@ -86,9 +86,9 @@ extension USearchIndex {
     /// - Parameter key: Unique identifier for that object.
     /// - Parameter vector: Double-precision vector.
     /// - Throws: If runs out of memory.
-    public func add(key: Key, vector: ArraySlice<Float64>) {
-        vector.withContiguousStorageIfAvailable {
-            addDouble(key: key, vector: $0.baseAddress!)
+    public func add(key: Key, vector: ArraySlice<Float64>) throws {
+        try vector.withContiguousStorageIfAvailable {
+            try addDouble(key: key, vector: $0.baseAddress!)
         }
     }
 
@@ -96,8 +96,8 @@ extension USearchIndex {
     /// - Parameter key: Unique identifier for that object.
     /// - Parameter vector: Double-precision vector.
     /// - Throws: If runs out of memory.
-    public func add(key: Key, vector: [Float64]) {
-        add(key: key, vector: vector[...])
+    public func add(key: Key, vector: [Float64]) throws {
+        try add(key: key, vector: vector[...])
     }
 
     /// Approximate nearest neighbors search.
@@ -105,11 +105,11 @@ extension USearchIndex {
     /// - Parameter count: Upper limit on the number of matches to retrieve.
     /// - Returns: Labels and distances to closest approximate matches in decreasing similarity order.
     /// - Throws: If runs out of memory.
-    public func search(vector: ArraySlice<Float64>, count: Int) -> ([Key], [Float]) {
+    public func search(vector: ArraySlice<Float64>, count: Int) throws -> ([Key], [Float]) {
         var matches: [Key] = Array(repeating: 0, count: count)
         var distances: [Float] = Array(repeating: 0, count: count)
-        let results = vector.withContiguousStorageIfAvailable {
-            searchDouble(vector: $0.baseAddress!, count: CUnsignedInt(count), keys: &matches, distances: &distances)
+        let results = try vector.withContiguousStorageIfAvailable {
+            try searchDouble(vector: $0.baseAddress!, count: CUnsignedInt(count), keys: &matches, distances: &distances)
         }
         matches.removeLast(count - Int(results!))
         distances.removeLast(count - Int(results!))
@@ -121,8 +121,8 @@ extension USearchIndex {
     /// - Parameter count: Upper limit on the number of matches to retrieve.
     /// - Returns: Labels and distances to closest approximate matches in decreasing similarity order.
     /// - Throws: If runs out of memory.
-    public func search(vector: [Float64], count: Int) -> ([Key], [Float]) {
-        search(vector: vector[...], count: count)
+    public func search(vector: [Float64], count: Int) throws -> ([Key], [Float]) {
+        try search(vector: vector[...], count: count)
     }
 
     /// Retrieve vectors for a given key.
@@ -130,11 +130,11 @@ extension USearchIndex {
     /// - Parameter count: For multi-indexes, Number of vectors to retrieve. Defaults to 1.
     /// - Returns: Two-dimensional array of Double-precision vectors.
     /// - Throws: If runs out of memory.
-    public func get(key: USearchKey, count: Int = 1) -> [[Float64]]? {
+    public func get(key: USearchKey, count: Int = 1) throws -> [[Float64]]? {
         var vector: [Float64] = Array(repeating: 0.0, count: Int(self.dimensions) * count)
-        let count = vector.withContiguousMutableStorageIfAvailable { buf in
+        let count = try vector.withContiguousMutableStorageIfAvailable { buf in
             guard let baseAddress = buf.baseAddress else { return UInt32(0) }
-            return getDouble(
+            return try getDouble(
                 key: key,
                 vector: baseAddress,
                 count: CUnsignedInt(count)
@@ -156,12 +156,12 @@ extension USearchIndex {
     /// - Parameter filter: Closure used to determine whether to skip a key in the results.
     /// - Returns: Labels and distances to closest approximate matches in decreasing similarity order.
     /// - Throws: If runs out of memory.
-    public func filteredSearch(vector: ArraySlice<Float32>, count: Int, filter: @escaping FilterFn) -> ([Key], [Float])
+    public func filteredSearch(vector: ArraySlice<Float32>, count: Int, filter: @escaping FilterFn) throws -> ([Key], [Float])
     {
         var matches: [Key] = Array(repeating: 0, count: count)
         var distances: [Float] = Array(repeating: 0, count: count)
-        let results = vector.withContiguousStorageIfAvailable {
-            filteredSearchSingle(
+        let results = try vector.withContiguousStorageIfAvailable {
+            try filteredSearchSingle(
                 vector: $0.baseAddress!,
                 count:
                     CUnsignedInt(count),
@@ -181,8 +181,8 @@ extension USearchIndex {
     /// - Parameter filter: Closure used to determine whether to skip a key in the results.
     /// - Returns: Labels and distances to closest approximate matches in decreasing similarity order.
     /// - Throws: If runs out of memory.
-    public func filteredSearch(vector: [Float32], count: Int, filter: @escaping FilterFn) -> ([Key], [Float]) {
-        filteredSearch(vector: vector[...], count: count, filter: filter)
+    public func filteredSearch(vector: [Float32], count: Int, filter: @escaping FilterFn) throws -> ([Key], [Float]) {
+        try filteredSearch(vector: vector[...], count: count, filter: filter)
     }
 
     /// Approximate nearest neighbors search.
@@ -191,12 +191,12 @@ extension USearchIndex {
     /// - Parameter filter: Closure used to determine whether to skip a key in the results.
     /// - Returns: Labels and distances to closest approximate matches in decreasing similarity order.
     /// - Throws: If runs out of memory.
-    public func filteredSearch(vector: ArraySlice<Float64>, count: Int, filter: @escaping FilterFn) -> ([Key], [Float])
+    public func filteredSearch(vector: ArraySlice<Float64>, count: Int, filter: @escaping FilterFn) throws -> ([Key], [Float])
     {
         var matches: [Key] = Array(repeating: 0, count: count)
         var distances: [Float] = Array(repeating: 0, count: count)
-        let results = vector.withContiguousStorageIfAvailable {
-            filteredSearchDouble(
+        let results = try vector.withContiguousStorageIfAvailable {
+            try filteredSearchDouble(
                 vector: $0.baseAddress!,
                 count:
                     CUnsignedInt(count),
@@ -216,8 +216,8 @@ extension USearchIndex {
     /// - Parameter filter: Closure used to determine whether to skip a key in the results.
     /// - Returns: Labels and distances to closest approximate matches in decreasing similarity order.
     /// - Throws: If runs out of memory.
-    public func filteredSearch(vector: [Float64], count: Int, filter: @escaping FilterFn) -> ([Key], [Float]) {
-        filteredSearch(vector: vector[...], count: count, filter: filter)
+    public func filteredSearch(vector: [Float64], count: Int, filter: @escaping FilterFn) throws -> ([Key], [Float]) {
+        try filteredSearch(vector: vector[...], count: count, filter: filter)
     }
 
     #if arch(arm64)
@@ -227,9 +227,9 @@ extension USearchIndex {
         /// - Parameter vector: Half-precision vector.
         /// - Throws: If runs out of memory.
         @available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)
-        public func add(key: Key, vector: ArraySlice<Float16>) {
-            vector.withContiguousStorageIfAvailable { buffer in
-                addHalf(key: key, vector: buffer.baseAddress!)
+        public func add(key: Key, vector: ArraySlice<Float16>) throws {
+            try vector.withContiguousStorageIfAvailable { buffer in
+                try addHalf(key: key, vector: buffer.baseAddress!)
             }
         }
 
@@ -238,8 +238,8 @@ extension USearchIndex {
         /// - Parameter vector: Half-precision vector.
         /// - Throws: If runs out of memory.
         @available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)
-        public func add(key: Key, vector: [Float16]) {
-            add(key: key, vector: vector[...])
+        public func add(key: Key, vector: [Float16]) throws {
+            try add(key: key, vector: vector[...])
         }
 
         /// Approximate nearest neighbors search.
@@ -248,11 +248,11 @@ extension USearchIndex {
         /// - Returns: Labels and distances to closest approximate matches in decreasing similarity order.
         /// - Throws: If runs out of memory.
         @available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)
-        public func search(vector: ArraySlice<Float16>, count: Int) -> ([Key], [Float]) {
+        public func search(vector: ArraySlice<Float16>, count: Int) throws -> ([Key], [Float]) {
             var matches: [Key] = Array(repeating: 0, count: count)
             var distances: [Float] = Array(repeating: 0, count: count)
-            let results = vector.withContiguousStorageIfAvailable {
-                searchHalf(vector: $0.baseAddress!, count: CUnsignedInt(count), keys: &matches, distances: &distances)
+            let results = try vector.withContiguousStorageIfAvailable {
+                try searchHalf(vector: $0.baseAddress!, count: CUnsignedInt(count), keys: &matches, distances: &distances)
             }
             matches.removeLast(count - Int(results!))
             distances.removeLast(count - Int(results!))
@@ -265,8 +265,8 @@ extension USearchIndex {
         /// - Returns: Labels and distances to closest approximate matches in decreasing similarity order.
         /// - Throws: If runs out of memory.
         @available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)
-        public func search(vector: [Float16], count: Int) -> ([Key], [Float]) {
-            search(vector: vector[...], count: count)
+        public func search(vector: [Float16], count: Int) throws -> ([Key], [Float]) {
+            try search(vector: vector[...], count: count)
         }
 
         /// Retrieve vectors for a given key.
@@ -275,11 +275,11 @@ extension USearchIndex {
         /// - Returns: Two-dimensional array of Half-precision vectors.
         /// - Throws: If runs out of memory.
         @available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)
-        public func get(key: USearchKey, count: Int = 1) -> [[Float16]]? {
+        public func get(key: USearchKey, count: Int = 1) throws -> [[Float16]]? {
             var vector: [Float16] = Array(repeating: 0.0, count: Int(self.dimensions) * count)
-            let count = vector.withContiguousMutableStorageIfAvailable { buf in
+            let count = try vector.withContiguousMutableStorageIfAvailable { buf in
                 guard let baseAddress = buf.baseAddress else { return UInt32(0) }
-                return getSingle(
+                return try getSingle(
                     key: key,
                     vector: baseAddress,
                     count: CUnsignedInt(count)

--- a/swift/Test.swift
+++ b/swift/Test.swift
@@ -1,5 +1,5 @@
 //
-//  File.swift
+//  Test.swift
 //
 //
 //  Created by Ash Vardanian on 5/11/23.
@@ -12,7 +12,7 @@ import XCTest
 @available(iOS 13, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
 class Test: XCTestCase {
     func testUnit() throws {
-        let index = USearchIndex.make(
+        let index = try USearchIndex.make(
             metric: USearchMetric.l2sq,
             dimensions: 4,
             connectivity: 8,
@@ -20,37 +20,37 @@ class Test: XCTestCase {
         )
         let vectorA: [Float32] = [0.3, 0.5, 1.2, 1.4]
         let vectorB: [Float32] = [0.4, 0.2, 1.2, 1.1]
-        index.reserve(2)
+        try index.reserve(2)
 
         // Adding a slice
-        index.add(key: 42, vector: vectorA[...])
+        try index.add(key: 42, vector: vectorA[...])
 
         // Adding a vector
-        index.add(key: 43, vector: vectorB)
+        try index.add(key: 43, vector: vectorB)
 
-        let results = index.search(vector: vectorA, count: 10)
+        let results = try index.search(vector: vectorA, count: 10)
         XCTAssertEqual(results.0[0], 42)
 
-        let fetched: [[Float]]? = index.get(key: 42)
+        let fetched: [[Float]]? = try index.get(key: 42)
         XCTAssertEqual(fetched?[0], vectorA)
 
-        XCTAssertTrue(index.contains(key: 42))
-        XCTAssertEqual(index.count(key: 42), 1)
-        XCTAssertEqual(index.count(key: 49), 0)
-        index.rename(from: 42, to: 49)
-        XCTAssertEqual(index.count(key: 49), 1)
+        XCTAssertTrue(try index.contains(key: 42))
+        XCTAssertEqual(try index.count(key: 42), 1)
+        XCTAssertEqual(try index.count(key: 49), 0)
+        try index.rename(from: 42, to: 49)
+        XCTAssertEqual(try index.count(key: 49), 1)
 
-        let refetched: [[Float]]? = index.get(key: 49)
+        let refetched: [[Float]]? = try index.get(key: 49)
         XCTAssertEqual(refetched?[0], vectorA)
-        let stale: [[Float]]? = index.get(key: 42)
+        let stale: [[Float]]? = try index.get(key: 42)
         XCTAssertNil(stale)
 
-        index.remove(key: 49)
-        XCTAssertEqual(index.count(key: 49), 0)
+        try index.remove(key: 49)
+        XCTAssertEqual(try index.count(key: 49), 0)
     }
 
     func testUnitMulti() throws {
-        let index = USearchIndex.make(
+        let index = try USearchIndex.make(
             metric: USearchMetric.l2sq,
             dimensions: 4,
             connectivity: 8,
@@ -59,85 +59,85 @@ class Test: XCTestCase {
         )
         let vectorA: [Float32] = [0.3, 0.5, 1.2, 1.4]
         let vectorB: [Float32] = [0.4, 0.2, 1.2, 1.1]
-        index.reserve(2)
+        try index.reserve(2)
 
         // Adding a slice
-        index.add(key: 42, vector: vectorA[...])
+        try index.add(key: 42, vector: vectorA[...])
 
         // Adding a vector
-        index.add(key: 42, vector: vectorB)
+        try index.add(key: 42, vector: vectorB)
 
-        let results = index.search(vector: vectorA, count: 10)
+        let results = try index.search(vector: vectorA, count: 10)
         XCTAssertEqual(results.0[0], 42)
 
-        let fetched: [[Float]]? = index.get(key: 42, count: 2)
+        let fetched: [[Float]]? = try index.get(key: 42, count: 2)
         XCTAssertEqual(fetched?.contains(vectorA), true)
         XCTAssertEqual(fetched?.contains(vectorB), true)
 
-        XCTAssertTrue(index.contains(key: 42))
-        XCTAssertEqual(index.count(key: 42), 2)
-        XCTAssertEqual(index.count(key: 49), 0)
-        index.rename(from: 42, to: 49)
-        XCTAssertEqual(index.count(key: 49), 2)
+        XCTAssertTrue(try index.contains(key: 42))
+        XCTAssertEqual(try index.count(key: 42), 2)
+        XCTAssertEqual(try index.count(key: 49), 0)
+        try index.rename(from: 42, to: 49)
+        XCTAssertEqual(try index.count(key: 49), 2)
 
-        let refetched: [[Float]]? = index.get(key: 49, count: 2)
+        let refetched: [[Float]]? = try index.get(key: 49, count: 2)
         XCTAssertEqual(refetched?.contains(vectorA), true)
         XCTAssertEqual(refetched?.contains(vectorB), true)
-        let stale: [[Float]]? = index.get(key: 42)
+        let stale: [[Float]]? = try index.get(key: 42)
         XCTAssertNil(stale)
 
-        index.remove(key: 49)
-        XCTAssertEqual(index.count(key: 49), 0)
+        try index.remove(key: 49)
+        XCTAssertEqual(try index.count(key: 49), 0)
     }
 
-    func testIssue399() {
-        let index = USearchIndex.make(
+    func testIssue399() throws {
+        let index = try USearchIndex.make(
             metric: USearchMetric.l2sq,
             dimensions: 1,
             connectivity: 8,
             quantization: USearchScalar.F32
         )
-        index.reserve(3)
+        try index.reserve(3)
 
         // add 3 entries then ensure all 3 are returned
-        index.add(key: 1, vector: [1.1])
-        index.add(key: 2, vector: [2.1])
-        index.add(key: 3, vector: [3.1])
+        try index.add(key: 1, vector: [1.1])
+        try index.add(key: 2, vector: [2.1])
+        try index.add(key: 3, vector: [3.1])
         XCTAssertEqual(index.count, 3)
-        XCTAssertEqual(index.search(vector: [1.0], count: 3).0, [1, 2, 3])  // works 😎
+        XCTAssertEqual(try index.search(vector: [1.0], count: 3).0, [1, 2, 3])  // works 😎
 
         // replace second-added entry then ensure all 3 are still returned
-        index.remove(key: 2)
-        index.add(key: 2, vector: [2.2])
+        try index.remove(key: 2)
+        try index.add(key: 2, vector: [2.2])
         XCTAssertEqual(index.count, 3)
-        XCTAssertEqual(index.search(vector: [1.0], count: 3).0, [1, 2, 3])  // works 😎
+        XCTAssertEqual(try index.search(vector: [1.0], count: 3).0, [1, 2, 3])  // works 😎
 
         // replace first-added entry then ensure all 3 are still returned
-        index.remove(key: 1)
-        index.add(key: 1, vector: [1.2])
-        let afterReplacingInitial = index.search(vector: [1.0], count: 3).0
+        try index.remove(key: 1)
+        try index.add(key: 1, vector: [1.2])
+        let afterReplacingInitial = try index.search(vector: [1.0], count: 3).0
         XCTAssertEqual(index.count, 3)
         XCTAssertEqual(afterReplacingInitial, [1, 2, 3])  // v2.11.7 fails with "[1] != [1, 2, 3]" 😨
     }
 
-    func testFilteredSearchSingle() {
-        let index = USearchIndex.make(
+    func testFilteredSearchSingle() throws {
+        let index = try USearchIndex.make(
             metric: USearchMetric.l2sq,
             dimensions: 1,
             connectivity: 8,
             quantization: USearchScalar.F32
         )
-        index.reserve(3)
+        try index.reserve(3)
 
         // add 3 entries
-        index.add(key: 1, vector: [1.1])
-        index.add(key: 2, vector: [2.1])
-        index.add(key: 3, vector: [3.1])
+        try index.add(key: 1, vector: [1.1])
+        try index.add(key: 2, vector: [2.1])
+        try index.add(key: 3, vector: [3.1])
         XCTAssertEqual(index.count, 3)
 
         // filter which accepts all keys:
         XCTAssertEqual(
-            index.filteredSearch(vector: [1.0], count: 3) {
+            try index.filteredSearch(vector: [1.0], count: 3) {
                 key in true
             }.0,
             [1, 2, 3]
@@ -145,7 +145,7 @@ class Test: XCTestCase {
 
         // filter which rejects all keys:
         XCTAssertEqual(
-            index.filteredSearch(vector: [1.0], count: 3) {
+            try index.filteredSearch(vector: [1.0], count: 3) {
                 key in false
             }.0,
             []
@@ -154,7 +154,7 @@ class Test: XCTestCase {
         // filter function accepts a set of keys passed in through a capture.
         let acceptedKeys: [USearchKey] = [1, 2]
         XCTAssertEqual(
-            index.filteredSearch(vector: [1.0], count: 3) {
+            try index.filteredSearch(vector: [1.0], count: 3) {
                 key in acceptedKeys.contains(key)
             }.0,
             acceptedKeys
@@ -163,37 +163,37 @@ class Test: XCTestCase {
         // filter function accepts a set of keys passed in through a capture,
         // and also adheres to the count.
         XCTAssertEqual(
-            index.filteredSearch(vector: [1.0], count: 1) {
+            try index.filteredSearch(vector: [1.0], count: 1) {
                 key in key > 1
             }.0,
             [2]
         )  // works 😎
         XCTAssertEqual(
-            index.filteredSearch(vector: [1.0], count: 2) {
+            try index.filteredSearch(vector: [1.0], count: 2) {
                 key in key > 1
             }.0,
             [2, 3]
         )  // works 😎
     }
 
-    func testFilteredSearchDouble() {
-        let index = USearchIndex.make(
+    func testFilteredSearchDouble() throws {
+        let index = try USearchIndex.make(
             metric: USearchMetric.l2sq,
             dimensions: 1,
             connectivity: 8,
             quantization: USearchScalar.F64
         )
-        index.reserve(3)
+        try index.reserve(3)
 
         // add 3 entries
-        index.add(key: 1, vector: [Float64(1.1)])
-        index.add(key: 2, vector: [Float64(2.1)])
-        index.add(key: 3, vector: [Float64(3.1)])
+        try index.add(key: 1, vector: [Float64(1.1)])
+        try index.add(key: 2, vector: [Float64(2.1)])
+        try index.add(key: 3, vector: [Float64(3.1)])
         XCTAssertEqual(index.count, 3)
 
         // filter which accepts all keys:
         XCTAssertEqual(
-            index.filteredSearch(vector: [Float64(1.0)], count: 3) {
+            try index.filteredSearch(vector: [Float64(1.0)], count: 3) {
                 key in true
             }.0,
             [1, 2, 3]
@@ -201,7 +201,7 @@ class Test: XCTestCase {
 
         // filter which rejects all keys:
         XCTAssertEqual(
-            index.filteredSearch(vector: [Float64(1.0)], count: 3) {
+            try index.filteredSearch(vector: [Float64(1.0)], count: 3) {
                 key in false
             }.0,
             []
@@ -210,7 +210,7 @@ class Test: XCTestCase {
         // filter function accepts a set of keys passed in through a capture.
         let acceptedKeys: [USearchKey] = [1, 2]
         XCTAssertEqual(
-            index.filteredSearch(vector: [Float64(1.0)], count: 3) {
+            try index.filteredSearch(vector: [Float64(1.0)], count: 3) {
                 key in acceptedKeys.contains(key)
             }.0,
             acceptedKeys
@@ -219,13 +219,13 @@ class Test: XCTestCase {
         // filter function accepts a set of keys passed in through a capture,
         // and also respects the count.
         XCTAssertEqual(
-            index.filteredSearch(vector: [Float64(1.0)], count: 1) {
+            try index.filteredSearch(vector: [Float64(1.0)], count: 1) {
                 key in key > 1
             }.0,
             [2]
         )  // works 😎
         XCTAssertEqual(
-            index.filteredSearch(vector: [Float64(1.0)], count: 2) {
+            try index.filteredSearch(vector: [Float64(1.0)], count: 2) {
                 key in key > 1
             }.0,
             [2, 3]

--- a/swift/Test.swift
+++ b/swift/Test.swift
@@ -16,7 +16,7 @@ class Test: XCTestCase {
             metric: USearchMetric.l2sq,
             dimensions: 4,
             connectivity: 8,
-            quantization: USearchScalar.F32
+            quantization: USearchScalar.f32
         )
         let vectorA: [Float32] = [0.3, 0.5, 1.2, 1.4]
         let vectorB: [Float32] = [0.4, 0.2, 1.2, 1.1]
@@ -54,7 +54,7 @@ class Test: XCTestCase {
             metric: USearchMetric.l2sq,
             dimensions: 4,
             connectivity: 8,
-            quantization: USearchScalar.F32,
+            quantization: USearchScalar.f32,
             multi: true
         )
         let vectorA: [Float32] = [0.3, 0.5, 1.2, 1.4]
@@ -95,7 +95,7 @@ class Test: XCTestCase {
             metric: USearchMetric.l2sq,
             dimensions: 1,
             connectivity: 8,
-            quantization: USearchScalar.F32
+            quantization: USearchScalar.f32
         )
         try index.reserve(3)
 
@@ -103,20 +103,20 @@ class Test: XCTestCase {
         try index.add(key: 1, vector: [1.1])
         try index.add(key: 2, vector: [2.1])
         try index.add(key: 3, vector: [3.1])
-        XCTAssertEqual(index.count, 3)
+        try XCTAssertEqual(index.count, 3)
         XCTAssertEqual(try index.search(vector: [1.0], count: 3).0, [1, 2, 3])  // works 😎
 
         // replace second-added entry then ensure all 3 are still returned
         try index.remove(key: 2)
         try index.add(key: 2, vector: [2.2])
-        XCTAssertEqual(index.count, 3)
+        try XCTAssertEqual(index.count, 3)
         XCTAssertEqual(try index.search(vector: [1.0], count: 3).0, [1, 2, 3])  // works 😎
 
         // replace first-added entry then ensure all 3 are still returned
         try index.remove(key: 1)
         try index.add(key: 1, vector: [1.2])
         let afterReplacingInitial = try index.search(vector: [1.0], count: 3).0
-        XCTAssertEqual(index.count, 3)
+        try XCTAssertEqual(index.count, 3)
         XCTAssertEqual(afterReplacingInitial, [1, 2, 3])  // v2.11.7 fails with "[1] != [1, 2, 3]" 😨
     }
 
@@ -125,7 +125,7 @@ class Test: XCTestCase {
             metric: USearchMetric.l2sq,
             dimensions: 1,
             connectivity: 8,
-            quantization: USearchScalar.F32
+            quantization: USearchScalar.f32
         )
         try index.reserve(3)
 
@@ -133,7 +133,7 @@ class Test: XCTestCase {
         try index.add(key: 1, vector: [1.1])
         try index.add(key: 2, vector: [2.1])
         try index.add(key: 3, vector: [3.1])
-        XCTAssertEqual(index.count, 3)
+        try XCTAssertEqual(index.count, 3)
 
         // filter which accepts all keys:
         XCTAssertEqual(
@@ -181,7 +181,7 @@ class Test: XCTestCase {
             metric: USearchMetric.l2sq,
             dimensions: 1,
             connectivity: 8,
-            quantization: USearchScalar.F64
+            quantization: USearchScalar.f64
         )
         try index.reserve(3)
 
@@ -189,7 +189,7 @@ class Test: XCTestCase {
         try index.add(key: 1, vector: [Float64(1.1)])
         try index.add(key: 2, vector: [Float64(2.1)])
         try index.add(key: 3, vector: [Float64(3.1)])
-        XCTAssertEqual(index.count, 3)
+        try XCTAssertEqual(index.count, 3)
 
         // filter which accepts all keys:
         XCTAssertEqual(

--- a/swift/Test.swift
+++ b/swift/Test.swift
@@ -37,15 +37,15 @@ class Test: XCTestCase {
         XCTAssertTrue(try index.contains(key: 42))
         XCTAssertEqual(try index.count(key: 42), 1)
         XCTAssertEqual(try index.count(key: 49), 0)
-        try index.rename(from: 42, to: 49)
+        try _ = index.rename(from: 42, to: 49)
         XCTAssertEqual(try index.count(key: 49), 1)
 
-        let refetched: [[Float]]? = try index.get(key: 49)
-        XCTAssertEqual(refetched?[0], vectorA)
+        let fetched_renamed: [[Float]]? = try index.get(key: 49)
+        XCTAssertEqual(fetched_renamed?[0], vectorA)
         let stale: [[Float]]? = try index.get(key: 42)
         XCTAssertNil(stale)
 
-        try index.remove(key: 49)
+        try _ = index.remove(key: 49)
         XCTAssertEqual(try index.count(key: 49), 0)
     }
 
@@ -86,7 +86,7 @@ class Test: XCTestCase {
         let stale: [[Float]]? = try index.get(key: 42)
         XCTAssertNil(stale)
 
-        try index.remove(key: 49)
+        try _ = index.remove(key: 49)
         XCTAssertEqual(try index.count(key: 49), 0)
     }
 
@@ -107,13 +107,13 @@ class Test: XCTestCase {
         XCTAssertEqual(try index.search(vector: [1.0], count: 3).0, [1, 2, 3])  // works 😎
 
         // replace second-added entry then ensure all 3 are still returned
-        try index.remove(key: 2)
+        try _ = index.remove(key: 2)
         try index.add(key: 2, vector: [2.2])
         try XCTAssertEqual(index.count, 3)
         XCTAssertEqual(try index.search(vector: [1.0], count: 3).0, [1, 2, 3])  // works 😎
 
         // replace first-added entry then ensure all 3 are still returned
-        try index.remove(key: 1)
+        try _ = index.remove(key: 1)
         try index.add(key: 1, vector: [1.2])
         let afterReplacingInitial = try index.search(vector: [1.0], count: 3).0
         try XCTAssertEqual(index.count, 3)

--- a/swift/Test.swift
+++ b/swift/Test.swift
@@ -29,24 +29,24 @@ class Test: XCTestCase {
         index.add(key: 43, vector: vectorB)
 
         let results = index.search(vector: vectorA, count: 10)
-        assert(results.0[0] == 42)
+        XCTAssertEqual(results.0[0], 42)
 
         let fetched: [[Float]]? = index.get(key: 42)
-        assert(fetched?[0] == vectorA)
+        XCTAssertEqual(fetched?[0], vectorA)
 
-        assert(index.contains(key: 42))
-        assert(index.count(key: 42) == 1)
-        assert(index.count(key: 49) == 0)
+        XCTAssertTrue(index.contains(key: 42))
+        XCTAssertEqual(index.count(key: 42), 1)
+        XCTAssertEqual(index.count(key: 49), 0)
         index.rename(from: 42, to: 49)
-        assert(index.count(key: 49) == 1)
+        XCTAssertEqual(index.count(key: 49), 1)
 
         let refetched: [[Float]]? = index.get(key: 49)
-        assert(refetched?[0] == vectorA)
+        XCTAssertEqual(refetched?[0], vectorA)
         let stale: [[Float]]? = index.get(key: 42)
-        assert(stale == nil)
+        XCTAssertNil(stale)
 
         index.remove(key: 49)
-        assert(index.count(key: 49) == 0)
+        XCTAssertEqual(index.count(key: 49), 0)
     }
 
     func testUnitMulti() throws {
@@ -68,26 +68,26 @@ class Test: XCTestCase {
         index.add(key: 42, vector: vectorB)
 
         let results = index.search(vector: vectorA, count: 10)
-        assert(results.0[0] == 42)
+        XCTAssertEqual(results.0[0], 42)
 
         let fetched: [[Float]]? = index.get(key: 42, count: 2)
-        assert(fetched?.contains(vectorA) == true)
-        assert(fetched?.contains(vectorB) == true)
+        XCTAssertEqual(fetched?.contains(vectorA), true)
+        XCTAssertEqual(fetched?.contains(vectorB), true)
 
-        assert(index.contains(key: 42))
-        assert(index.count(key: 42) == 2)
-        assert(index.count(key: 49) == 0)
+        XCTAssertTrue(index.contains(key: 42))
+        XCTAssertEqual(index.count(key: 42), 2)
+        XCTAssertEqual(index.count(key: 49), 0)
         index.rename(from: 42, to: 49)
-        assert(index.count(key: 49) == 2)
+        XCTAssertEqual(index.count(key: 49), 2)
 
         let refetched: [[Float]]? = index.get(key: 49, count: 2)
-        assert(refetched?.contains(vectorA) == true)
-        assert(refetched?.contains(vectorB) == true)
+        XCTAssertEqual(refetched?.contains(vectorA), true)
+        XCTAssertEqual(refetched?.contains(vectorB), true)
         let stale: [[Float]]? = index.get(key: 42)
-        assert(stale == nil)
+        XCTAssertNil(stale)
 
         index.remove(key: 49)
-        assert(index.count(key: 49) == 0)
+        XCTAssertEqual(index.count(key: 49), 0)
     }
 
     func testIssue399() {

--- a/swift/USearch.swift
+++ b/swift/USearch.swift
@@ -1,8 +1,0 @@
-//
-//  File.swift
-//
-//
-//  Created by Ash Vardanian on 5/11/23.
-//
-
-@_exported import USearchObjective

--- a/swift/USearchIndex+Sugar.swift
+++ b/swift/USearchIndex+Sugar.swift
@@ -1,11 +1,11 @@
 //
-//  Index+Sugar.swift
+//  USearchIndex+Sugar.swift
 //
 //
 //  Created by Ash Vardanian on 5/11/23.
 //
 
-@available(iOS 13, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
+@available(iOS 13, macOS 11.0, tvOS 13.0, watchOS 6.0, *)
 extension USearchIndex {
     public typealias Key = USearchKey
     public typealias Metric = USearchMetric
@@ -63,7 +63,7 @@ extension USearchIndex {
     /// - Returns: Two-dimensional array of Single-precision vectors.
     /// - Throws: If runs out of memory.
     public func get(key: USearchKey, count: Int = 1) throws -> [[Float]]? {
-        var vector: [Float] = Array(repeating: 0.0, count: Int(self.dimensions) * count)
+        var vector: [Float] = try Array(repeating: 0.0, count: Int(self.dimensions) * count)
         let returnedCount = try vector.withContiguousMutableStorageIfAvailable { buf in
             guard let baseAddress = buf.baseAddress else { return UInt32(0) }
             return try getSingle(
@@ -73,12 +73,12 @@ extension USearchIndex {
             )
         }
         guard let count = returnedCount, count > 0 else { return nil }
-        return stride(
+        return try stride(
             from: 0,
-            to: Int(count) * Int(self.dimensions),
-            by: Int(self.dimensions)
+            to: try Int(count) * Int(self.dimensions),
+            by: try Int(self.dimensions)
         ).map {
-            Array(vector[$0 ..< $0 + Int(self.dimensions)])
+            try Array(vector[$0 ..< $0 + Int(self.dimensions)])
         }
     }
 
@@ -131,7 +131,7 @@ extension USearchIndex {
     /// - Returns: Two-dimensional array of Double-precision vectors.
     /// - Throws: If runs out of memory.
     public func get(key: USearchKey, count: Int = 1) throws -> [[Float64]]? {
-        var vector: [Float64] = Array(repeating: 0.0, count: Int(self.dimensions) * count)
+        var vector: [Float64] = try Array(repeating: 0.0, count: Int(self.dimensions) * count)
         let count = try vector.withContiguousMutableStorageIfAvailable { buf in
             guard let baseAddress = buf.baseAddress else { return UInt32(0) }
             return try getDouble(
@@ -141,12 +141,12 @@ extension USearchIndex {
             )
         }
         guard let count = count, count > 0 else { return nil }
-        return stride(
+        return try stride(
             from: 0,
-            to: Int(count) * Int(self.dimensions),
-            by: Int(self.dimensions)
+            to: try Int(count) * Int(self.dimensions),
+            by: try Int(self.dimensions)
         ).map {
-            Array(vector[$0 ..< $0 + Int(self.dimensions)])
+            try Array(vector[$0 ..< $0 + Int(self.dimensions)])
         }
     }
 
@@ -276,27 +276,31 @@ extension USearchIndex {
         /// - Throws: If runs out of memory.
         @available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)
         public func get(key: USearchKey, count: Int = 1) throws -> [[Float16]]? {
-            var vector: [Float16] = Array(repeating: 0.0, count: Int(self.dimensions) * count)
+            var vector: [Float16] = try Array(repeating: 0.0, count: Int(self.dimensions) * count)
             let count = try vector.withContiguousMutableStorageIfAvailable { buf in
                 guard let baseAddress = buf.baseAddress else { return UInt32(0) }
-                return try getSingle(
+                return try getHalf(
                     key: key,
                     vector: baseAddress,
                     count: CUnsignedInt(count)
                 )
             }
             guard let count = count, count > 0 else { return nil }
-            return stride(
+            return try stride(
                 from: 0,
-                to: Int(count) * Int(self.dimensions),
-                by: Int(self.dimensions)
+                to: try Int(count) * Int(self.dimensions),
+                by: try Int(self.dimensions)
             ).map {
-                Array(vector[$0 ..< $0 + Int(self.dimensions)])
+                try Array(vector[$0 ..< $0 + Int(self.dimensions)])
             }
         }
 
     #endif
 
     /// Number of vectors in the index.
-    public var count: Int { return Int(length) }
+    public var count: Int {
+        get throws {
+            return try Int(length)
+        }
+    }
 }

--- a/swift/USearchIndex.swift
+++ b/swift/USearchIndex.swift
@@ -1,0 +1,428 @@
+//
+//  USearchIndex.swift
+//
+//
+//  Created by Dan Palmer on 9/2/25.
+//
+
+import Foundation
+import usearch_c
+
+public enum USearchScalar: UInt {
+    case f32
+    case f16
+    case f64
+    case i8
+    case b1
+}
+
+public enum USearchMetric: UInt {
+    case ip
+    case cos
+    case l2sq
+    case pearson
+    case haversine
+    case divergence
+    case jaccard
+    case hamming
+    case tanimoto
+    case sorensen
+}
+
+public typealias USearchKey = UInt64
+public typealias USearchFilterFn = (USearchKey) -> Bool
+
+extension USearchMetric {
+    func toNative() -> usearch_metric_kind_t {
+        switch self {
+        case .ip:
+            return usearch_metric_ip_k
+        case .cos:
+            return usearch_metric_cos_k
+        case .l2sq:
+            return usearch_metric_l2sq_k
+        case .hamming:
+            return usearch_metric_hamming_k
+        case .haversine:
+            return usearch_metric_haversine_k
+        case .divergence:
+            return usearch_metric_divergence_k
+        case .jaccard:
+            return usearch_metric_jaccard_k
+        case .pearson:
+            return usearch_metric_pearson_k
+        case .sorensen:
+            return usearch_metric_sorensen_k
+        case .tanimoto:
+            return usearch_metric_tanimoto_k
+        }
+    }
+}
+
+extension USearchScalar {
+    func toNative() -> usearch_scalar_kind_t {
+        switch self {
+        case .i8:
+            return usearch_scalar_i8_k
+        case .f16:
+            return usearch_scalar_f16_k
+        case .b1:
+            return usearch_scalar_b1_k
+        case .f32:
+            return usearch_scalar_f32_k
+        case .f64:
+            return usearch_scalar_f64_k
+        }
+    }
+}
+
+public enum USearchError: Error {
+    case outOfMemory
+    case unknownScalarKind
+    case unknownMetricKind
+
+    case pathNotUTF8Encodable
+
+    case unknownError(String)
+
+    static func fromErrorString(_ errorString: String) -> USearchError? {
+        switch errorString {
+        case "Out of memory!", "Out of memory when preparing contexts!", "Out of memory, allocating a temporary buffer for batch results":
+            return .outOfMemory
+        case "Unknown scalar kind!":
+            return .unknownScalarKind
+        case "Unknown metric kind!":
+            return .unknownMetricKind
+        default:
+            return nil
+        }
+    }
+}
+
+
+@available(iOS 13.0, macOS 11.0, tvOS 13.0, watchOS 6.0, *)
+public class USearchIndex: NSObject {
+    private var nativeIndex: usearch_index_t
+
+    private init(native: consuming usearch_index_t) throws {
+        nativeIndex = native
+        super.init()
+    }
+
+    var dimensions: UInt32 {
+        get throws {
+            return try UInt32(throwing { usearch_dimensions(nativeIndex, $0) })
+        }
+    }
+
+    var connectivity: UInt32 {
+        get throws {
+            return try UInt32(throwing { usearch_connectivity(nativeIndex, $0) })
+        }
+    }
+
+    var expansionAdd: UInt32 {
+        get throws {
+            return try UInt32(throwing { usearch_expansion_add(nativeIndex, $0) })
+        }
+    }
+
+    var expansionSearch: UInt32 {
+        get throws {
+            return try UInt32(throwing { usearch_expansion_search(nativeIndex, $0) })
+        }
+    }
+
+    var length: UInt32 {
+        get throws {
+            return try UInt32(throwing { usearch_size(nativeIndex, $0) })
+        }
+    }
+
+    var capacity: UInt32 {
+        get throws {
+            return try UInt32(throwing { usearch_capacity(nativeIndex, $0) })
+        }
+    }
+
+    /**
+     * @brief Initializes a new index.
+     * @param metric The distance function to compare the dis-similarity of vectors.
+     * @param dimensions The number of dimensions planned for this index.
+     * @param connectivity Number of connections per node in the proximity graph.
+     * Higher connectivity improves quantization, increases memory usage, and reduces construction speed.
+     * @param quantization Quantization of internal vector representations. Lower quantization means higher speed.
+     */
+    public static func make(metric: USearchMetric, dimensions: UInt32, connectivity: UInt32, quantization: USearchScalar) throws -> USearchIndex {
+        return try make(metric: metric, dimensions: dimensions, connectivity: connectivity, quantization: quantization, multi: false)
+    }
+
+    /**
+     * @brief Initializes a new index.
+     * @param metric The distance function to compare the dis-similarity of vectors.
+     * @param dimensions The number of dimensions planned for this index.
+     * @param connectivity Number of connections per node in the proximity graph.
+     * Higher connectivity improves quantization, increases memory usage, and reduces construction speed.
+     * @param quantization Quantization of internal vector representations. Lower quantization means higher speed.
+     * @param multi Enables indexing multiple vectors per key when true.
+     */
+    public static func make(metric: USearchMetric, dimensions: UInt32, connectivity: UInt32, quantization: USearchScalar, multi: Bool) throws -> USearchIndex {
+        let options = usearch_init_options_t(
+            metric_kind: metric.toNative(),
+            metric: nil,
+            quantization: quantization.toNative(),
+            dimensions: Int(dimensions),
+            connectivity: Int(connectivity),
+            expansion_add: 0,
+            expansion_search: 0,
+            multi: multi
+        )
+
+
+        let optionsPtr = pointer(options)
+        let index = try throwing { usearch_init(optionsPtr, $0) }
+        guard let index else {
+            throw USearchError.unknownError("No index created, no error returned.")
+        }
+
+        return try USearchIndex(native: index)
+    }
+
+    public var isEmpty: Bool {
+        get throws {
+            return (try throwing { usearch_size(nativeIndex, $0) } != 0)
+        }
+    }
+
+    override public var description: String {
+        do {
+            return try "USearchIndex(dimensions: \(dimensions), connectivity: \(connectivity), length: \(length), capacity: \(capacity), isEmpty: \(isEmpty))"
+        } catch {
+            return "USearchIndex(error: \(error))"
+        }
+    }
+
+    /**
+     * @brief Pre-allocates space in the index for the given number of vectors.
+     */
+    public func reserve(_ count: UInt32) throws {
+        try throwing { usearch_reserve(nativeIndex, Int(count), $0) }
+    }
+
+    /**
+     * @brief Adds a labeled vector to the index.
+     * @param vector Single-precision vector.
+     */
+    public func addSingle(key: USearchKey, vector: UnsafePointer<Float32>) throws {
+        try throwing { usearch_add(nativeIndex, key, vector, USearchScalar.f32.toNative(), $0) }
+    }
+
+    /**
+     * @brief Approximate nearest neighbors search.
+     * @param vector Single-precision query vector.
+     * @param count Upper limit on the number of matches to retrieve.
+     * @param keys Optional output buffer for keys of approximate neighbors.
+     * @param distances Optional output buffer for (increasing) distances to approximate neighbors.
+     * @return Number of matches exported to `keys` and `distances`.
+     */
+    public func searchSingle(vector: UnsafePointer<Float32>, count: UInt32, keys: UnsafeMutablePointer<USearchKey>?, distances: UnsafeMutablePointer<Float32>?) throws -> UInt32 {
+        let found = try throwing { usearch_search(nativeIndex, vector, USearchScalar.f32.toNative(), Int(count), keys, distances, $0) }
+        return UInt32(found)
+    }
+
+    /**
+    * @brief Retrieves a labeled single-precision vector from the index.
+    * @param vector A buffer to store the vector.
+    * @param count For multi-indexes, the number of vectors to retrieve.
+    * @return Number of vectors exported to `vector`.
+    */
+    public func getSingle(key: USearchKey, vector: UnsafeMutablePointer<Float32>, count: UInt32) throws -> UInt32 {
+        let result = try throwing { usearch_get(nativeIndex, key, Int(count), vector, USearchScalar.f32.toNative(), $0) }
+        return UInt32(result)
+    }
+
+    /**
+     * @brief Approximate nearest neighbors search.
+     * @param vector Single-precision query vector.
+     * @param count Upper limit on the number of matches to retrieve.
+     * @param filter Closure called for each key, determining whether to include or
+     *               skip key in the results.
+     * @param keys Optional output buffer for keys of approximate neighbors.
+     * @param distances Optional output buffer for (increasing) distances to approximate neighbors.
+     * @return Number of matches exported to `keys` and `distances`.
+     */
+    public func filteredSearchSingle(vector: UnsafePointer<Float32>, count: UInt32, filter: @escaping USearchFilterFn, keys: UnsafeMutablePointer<USearchKey>?, distances: UnsafeMutablePointer<Float32>?) throws -> UInt32 {
+        return try filteredSearchGeneric(
+            nativeIndex,
+            vector: vector,
+            count: count,
+            quantization: .f32,
+            filter: filter,
+            keys: keys,
+            distances: distances
+        )
+    }
+
+    /**
+     * @brief Adds a labeled vector to the index.
+     * @param vector Double-precision vector.
+     */
+    public func addDouble(key: USearchKey, vector: UnsafePointer<Float64>) throws {
+        try throwing { usearch_add(nativeIndex, key, vector, USearchScalar.f64.toNative(), $0) }
+    }
+
+    /**
+     * @brief Approximate nearest neighbors search.
+     * @param vector Double-precision query vector.
+     * @param count Upper limit on the number of matches to retrieve.
+     * @param keys Optional output buffer for keys of approximate neighbors.
+     * @param distances Optional output buffer for (increasing) distances to approximate neighbors.
+     * @return Number of matches exported to `keys` and `distances`.
+     */
+    public func searchDouble(vector: UnsafePointer<Float64>, count: UInt32, keys: UnsafeMutablePointer<USearchKey>?, distances: UnsafeMutablePointer<Float32>?) throws -> UInt32 {
+        let found = try throwing { usearch_search(nativeIndex, vector, USearchScalar.f64.toNative(), Int(count), keys, distances, $0) }
+        return UInt32(found)
+    }
+
+    /**
+    * @brief Retrieves a labeled double-precision vector from the index.
+    * @param vector A buffer to store the vector.
+    * @param count For multi-indexes, the number of vectors to retrieve.
+    * @return Number of vectors exported to `vector`.
+    */
+    public func getDouble(key: USearchKey, vector: UnsafeMutablePointer<Float64>, count: UInt32) throws -> UInt32 {
+        let result = try throwing { usearch_get(nativeIndex, key, Int(count), vector, USearchScalar.f64.toNative(),  $0) }
+        return UInt32(result)
+    }
+
+    /**
+     * @brief Approximate nearest neighbors search.
+     * @param vector Double-precision query vector.
+     * @param count Upper limit on the number of matches to retrieve.
+     * @param filter Closure called for each key, determining whether to include or
+     *               skip key in the results.
+     * @param keys Optional output buffer for keys of approximate neighbors.
+     * @param distances Optional output buffer for (increasing) distances to approximate neighbors.
+     * @return Number of matches exported to `keys` and `distances`.
+     */
+    public func filteredSearchDouble(vector: UnsafePointer<Float64>, count: UInt32, filter: @escaping USearchFilterFn, keys: UnsafeMutablePointer<USearchKey>?, distances: UnsafeMutablePointer<Float32>?) throws -> UInt32 {
+        return try filteredSearchGeneric(
+            nativeIndex,
+            vector: vector,
+            count: count,
+            quantization: .f64,
+            filter: filter,
+            keys: keys,
+            distances: distances
+        )
+    }
+
+    /**
+     * @brief Adds a labeled vector to the index.
+     * @param vector Half-precision vector.
+     */
+    public func addHalf(key: USearchKey, vector: UnsafePointer<Float16>) throws {
+        try throwing { usearch_add(nativeIndex, key, vector, USearchScalar.f16.toNative(), $0) }
+    }
+
+    /**
+     * @brief Approximate nearest neighbors search.
+     * @param vector Half-precision query vector.
+     * @param count Upper limit on the number of matches to retrieve.
+     * @param keys Optional output buffer for keys of approximate neighbors.
+     * @param distances Optional output buffer for (increasing) distances to approximate neighbors.
+     * @return Number of matches exported to `keys` and `distances`.
+     */
+    public func searchHalf(vector: UnsafePointer<Float16>, count: UInt32, keys: UnsafeMutablePointer<USearchKey>?, distances: UnsafeMutablePointer<Float32>?) throws -> UInt32 {
+        let found = try throwing { usearch_search(nativeIndex, vector, USearchScalar.f16.toNative(), Int(count), keys, distances, $0) }
+        return UInt32(found)
+    }
+
+    /**
+    * @brief Retrieves a labeled half-precision vector from the index.
+    * @param vector A buffer to store the vector.
+    * @param count For multi-indexes, the number of vectors to retrieve.
+    * @return Number of vectors exported to `vector`.
+    */
+    public func getHalf(key: USearchKey, vector: UnsafeMutablePointer<Float16>, count: UInt32) throws -> UInt32 {
+        let result = try throwing { usearch_get(nativeIndex, key, Int(count), vector, USearchScalar.f16.toNative(), $0) }
+        return UInt32(result)
+    }
+
+    /**
+     * @brief Approximate nearest neighbors search.
+     * @param vector Double-precision query vector.
+     * @param count Upper limit on the number of matches to retrieve.
+     * @param filter Closure called for each key, determining whether to include or
+     *               skip key in the results.
+     * @param keys Optional output buffer for keys of approximate neighbors.
+     * @param distances Optional output buffer for (increasing) distances to approximate neighbors.
+     * @return Number of matches exported to `keys` and `distances`.
+     */
+    public func filteredSearchHalf(vector: UnsafePointer<Float16>, count: UInt32, filter: @escaping USearchFilterFn, keys: UnsafeMutablePointer<USearchKey>?, distances: UnsafeMutablePointer<Float32>?) throws -> UInt32 {
+        return try filteredSearchGeneric(
+            nativeIndex,
+            vector: vector,
+            count: count,
+            quantization: .f16,
+            filter: filter,
+            keys: keys,
+            distances: distances
+        )
+    }
+
+    public func contains(key: USearchKey) throws -> Bool {
+        return try throwing { usearch_contains(nativeIndex, key, $0) }
+    }
+
+    public func count(key: USearchKey) throws -> UInt32 {
+        return UInt32(try throwing { usearch_count(nativeIndex, key, $0) })
+    }
+
+    public func remove(key: USearchKey) throws -> UInt32 {
+        return try UInt32(throwing { usearch_remove(nativeIndex, key, $0) })
+    }
+
+    public func rename(from key: USearchKey, to newKey: USearchKey) throws -> UInt32 {
+        return try UInt32(throwing { usearch_rename(nativeIndex, key, newKey, $0) })
+    }
+
+    /**
+     * @brief Saves pre-constructed index to disk.
+     */
+    public func save(path: String) throws {
+        guard let cPath = path.cString(using: .utf8) else {
+            throw USearchError.pathNotUTF8Encodable
+        }
+        try throwing { usearch_save(nativeIndex, cPath, $0) }
+    }
+
+    /**
+     * @brief Loads a pre-constructed index from index.
+     */
+    public func load(path: String) throws {
+        guard let cPath = path.cString(using: .utf8) else {
+            throw USearchError.pathNotUTF8Encodable
+        }
+        try throwing { usearch_load(nativeIndex, cPath, $0) }
+    }
+
+    /**
+     * @brief Views a pre-constructed index from disk without loading it into RAM.
+     *        Allows working with larger-than memory indexes and saving scarce
+     *        memory on device in read-only workloads.
+     */
+    public func view(path: String) throws {
+        guard let cPath = path.cString(using: .utf8) else {
+            throw USearchError.pathNotUTF8Encodable
+        }
+        try throwing { usearch_view(nativeIndex, cPath, $0) }
+    }
+
+    /**
+     * @brief Removes all the data from index, while preserving the settings.
+     */
+    public func clear() throws {
+        try throwing { usearch_clear(nativeIndex, $0) }
+    }
+}

--- a/swift/USearchIndex.swift
+++ b/swift/USearchIndex.swift
@@ -80,21 +80,82 @@ public enum USearchError: Error {
     case outOfMemory
     case unknownScalarKind
     case unknownMetricKind
+    case fileReadError
+    case fileTypeError
+    case keyLookupsDisabled
+    case keyMissing
+    case serializationError
+    case deserializationError
+    case immutableError
+    case keyCountError
+    case renameCollisionError
+    case indexTooSmallToClusterError
+    case duplicateKeysError
+    case reservationError
 
     case pathNotUTF8Encodable
 
     case unknownError(String)
 
-    static func fromErrorString(_ errorString: String) -> USearchError? {
+    static func fromErrorString(_ errorString: String) -> USearchError {
         switch errorString {
-        case "Out of memory!", "Out of memory when preparing contexts!", "Out of memory, allocating a temporary buffer for batch results":
+        case
+            "Out of memory!",
+            "Out of memory",
+            "Out of memory when preparing contexts!",
+            "Out of memory, allocating a temporary buffer for batch results",
+            "Failed to allocate memory for the index!",
+            "Failed to allocate memory for the casts",
+            "Failed to reserve memory for the index",
+            "Failed to allocate memory for the available threads!",
+            "Failed to allocate memory for the index",
+            "Can't allocate memory for a free-list",
+            "Failed to allocate memory for the casts!":
             return .outOfMemory
         case "Unknown scalar kind!":
             return .unknownScalarKind
         case "Unknown metric kind!":
             return .unknownMetricKind
+        case "End of file reached!", "Can't infer file size":
+            return .fileReadError
+        case "Not a dense USearch index!":
+            return .fileTypeError
+        case "Key lookups are disabled!":
+            return .keyLookupsDisabled
+        case "Key missing!":
+            return .keyMissing
+        case "Failed to serialize into stream":
+            return .serializationError
+        case
+            "Failed to read 32-bit dimensions of the matrix",
+            "Failed to read 64-bit dimensions of the matrix",
+            "Failed to allocate memory to address vectors",
+            "Failed to read vectors",
+            "Failed to read the index ", // space left intentionally blank
+            "Magic header mismatch - the file isn't an index",
+            "File format may be different, please rebuild",
+            "Key type doesn't match, consider rebuilding",
+            "Slot type doesn't match, consider rebuilding",
+            "Index size and the number of vectors doesn't match",
+            "File is corrupted and lacks matrix dimensions",
+            "File is corrupted and lacks a header":
+            return .deserializationError
+        case
+            "Can't add to an immutable index",
+            "Can't remove from an immutable index":
+            return .immutableError
+        case "Free keys count mismatch":
+            return .keyCountError
+        case "Renaming impossible, the key is already in use":
+            return .renameCollisionError
+        case "Index too small to cluster!":
+            return .indexTooSmallToClusterError
+        case "Duplicate keys not allowed in high-level wrappers":
+            return .duplicateKeysError
+        case "Reserve capacity ahead of insertions!":
+            return .reservationError
         default:
-            return nil
+            return .unknownError(errorString)
         }
     }
 }

--- a/swift/USearchIndex.swift
+++ b/swift/USearchIndex.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-import usearch_c
+import USearchC
 
 public enum USearchScalar: UInt {
     case f32

--- a/swift/Util.swift
+++ b/swift/Util.swift
@@ -1,0 +1,56 @@
+//
+//  Util.swift
+//  USearch
+//
+//  Created by Dan Palmer on 09/02/2025.
+//
+
+import usearch_c
+
+func throwing<T>(_ fn: (inout UnsafeMutablePointer<usearch_error_t?>) -> T) throws -> T {
+    var err: UnsafeMutablePointer<usearch_error_t?> = .allocate(capacity: 1)
+    let result = fn(&err)
+
+    guard let errorCString = err.pointee else {
+        return result
+    }
+
+    let errorString = String(cString: errorCString)
+    guard let error = USearchError.fromErrorString(errorString) else {
+        throw USearchError.unknownError(errorString)
+    }
+
+    throw error
+}
+
+func pointer<T>(_ value: T) -> UnsafeMutablePointer<T> {
+    let ptr = UnsafeMutablePointer<T>.allocate(capacity: 1)
+    ptr.initialize(to: value)
+    return ptr
+}
+
+class FilterWrapper {
+    let filter: USearchFilterFn
+
+    init(_ filter: @escaping USearchFilterFn) {
+        self.filter = filter
+    }
+}
+
+func filteredSearchGeneric<T>(_ index: usearch_index_t, vector: UnsafePointer<T>, count: UInt32, quantization: USearchScalar, filter: @escaping USearchFilterFn, keys: UnsafeMutablePointer<USearchKey>?, distances: UnsafeMutablePointer<Float32>?) throws -> UInt32 {
+    let filterBlock: (@convention(c) (usearch_key_t, UnsafeMutableRawPointer?) -> Int32) = { (key, state) in
+        let wrapper = Unmanaged<FilterWrapper>.fromOpaque(state!).takeUnretainedValue()
+        return wrapper.filter(key) ? 1 : 0
+    }
+
+    let unmanagedFilter = Unmanaged.passRetained(FilterWrapper(filter))
+    let filterState = UnsafeMutableRawPointer(unmanagedFilter.toOpaque())
+
+    let found = try throwing {
+        let ret = usearch_filtered_search(index, vector, quantization.toNative(), Int(count), filterBlock, filterState, keys, distances, $0)
+        unmanagedFilter.release()
+        return ret
+    }
+
+    return UInt32(found)
+}

--- a/swift/Util.swift
+++ b/swift/Util.swift
@@ -11,16 +11,11 @@ func throwing<T>(_ fn: (inout UnsafeMutablePointer<usearch_error_t?>) -> T) thro
     var err: UnsafeMutablePointer<usearch_error_t?> = .allocate(capacity: 1)
     let result = fn(&err)
 
-    guard let errorCString = err.pointee else {
-        return result
+    if let errorCString = err.pointee {
+        throw USearchError.fromErrorString(String(cString: errorCString))
     }
 
-    let errorString = String(cString: errorCString)
-    guard let error = USearchError.fromErrorString(errorString) else {
-        throw USearchError.unknownError(errorString)
-    }
-
-    throw error
+    return result
 }
 
 func pointer<T>(_ value: T) -> UnsafeMutablePointer<T> {

--- a/swift/Util.swift
+++ b/swift/Util.swift
@@ -5,16 +5,23 @@
 //  Created by Dan Palmer on 09/02/2025.
 //
 
-import usearch_c
+import USearchC
 
 func throwing<T>(_ fn: (inout UnsafeMutablePointer<usearch_error_t?>) -> T) throws -> T {
-    var err: UnsafeMutablePointer<usearch_error_t?> = .allocate(capacity: 1)
+    // Allocate and initialize the pointer to nil.
+    var err = UnsafeMutablePointer<usearch_error_t?>.allocate(capacity: 1)
+    err.initialize(to: nil)
+    
+    // Ensure the allocated memory is deallocated when done.
+    defer {
+        err.deinitialize(count: 1)
+        err.deallocate()
+    }
+    
     let result = fn(&err)
-
     if let errorCString = err.pointee {
         throw USearchError.fromErrorString(String(cString: errorCString))
     }
-
     return result
 }
 


### PR DESCRIPTION
This PR is a second attempt at #563, but using the C bindings as the basis for Swift interop, rather than the C++ interface. This adds a layer of indirection, but drastically simplifies the interop types. Given that Swift/C++ interop is not yet capable of expressing the necessary types for USearch, this is a better option to split the Objective-C and Swift codebases, and ultimately, to support Swift on Linux.

### What's changed

- A move to Swift errors (rather than NSExceptions). This was proposed separately in #554, and I'm still in favour of that change to improve the Objective-C API, but to have an error mechanism in the Swift API we need some of those changes.
- API consistency, the `clear` method was missing, and it would be better to remain mostly API compatible.
- A re-written Swift layer using the new `usearch_c` module, backed by the C implementation.

### What's _not_ changing

Other than the necessary introduction of throwing functions (remember that the Swift interface currently cannot handle any errors at all, they explicitly crash the application), there are no API changes to the high-level "Sugar" interface. Additionally the tests do not change, other than to support thrown errors.

For most projects this upgrade should be a straightforward process of adding `try`s to calls and handling errors. Most production users probably already wrap the Swift interface in Objective-C to be able to catch exceptions, and can therefore simplify their code significantly.

### Future improvements

These are purposefully left out of this implementation to keep it manageable and reviewable.

- **Actor support, proper threading control.** Currently USearch manages its own threading, there are limits to this though. We should try to figure out a Swift-appropriate way of bridging the gap. Possibly using a `MainActor` so that there is a guaranteed single instance, and internally manage the number of in-flight requests to the index up to the limit of the number of threads.
- **Better error support.** Currently USearch returns strings for errors. This makes sense for some languages, but in Swift we typically want an enum so that errors can be more informative and handled separately. A stable error code introduced on the C++ side could make this possible.
- **Objective-C Tests.** Previously this was tested _via_ the Swift implementation. Now this needs its own tests, ideally in Objective-C.
- **Improved Package structure.** Minor, but the structure, dependencies, includes/excludes, etc, could probably be tidied up a bit. Out of scope here though I think.
