### PR TITLE
Fix a correctness bug caused by a wrong memory override

### DIFF
--- a/include/usearch/index.hpp
+++ b/include/usearch/index.hpp
@@ -2499,13 +2499,12 @@ class index_gt {
         if (nodes_)
             std::memcpy(new_nodes.data(), nodes_.data(), sizeof(node_t) * size());
 
+        // Pre-reserve the capacity for `top_for_refine`, which always contains at most one more
+        // element than the connectivity factors.
         std::size_t connectivity_max = (std::max)(config_.connectivity_base, config_.connectivity);
-        // pre-reserve the capacity for 'top_for_refine'
-        for (size_t i = 0; i < new_contexts.size(); ++i) {
-            if (!new_contexts[i].top_for_refine.reserve(connectivity_max + 1)) {
+        for (std::size_t i = 0; i != new_contexts.size(); ++i)
+            if (!new_contexts[i].top_for_refine.reserve(connectivity_max + 1))
                 return false;
-            }
-        }
 
         limits_ = limits;
         nodes_capacity_ = limits.members;
@@ -3188,17 +3187,11 @@ class index_gt {
 
     std::size_t memory_usage_per_node(level_t level) const noexcept { return node_bytes_(level); }
 
-    double inverse_log_connectivity() const {
-        return pre_.inverse_log_connectivity;
-    }
+    double inverse_log_connectivity() const { return pre_.inverse_log_connectivity; }
 
-    std::size_t neighbors_base_bytes() const {
-        return pre_.neighbors_base_bytes;
-    }
+    std::size_t neighbors_base_bytes() const { return pre_.neighbors_base_bytes; }
 
-    std::size_t neighbors_bytes() const {
-        return pre_.neighbors_bytes;
-    }
+    std::size_t neighbors_bytes() const { return pre_.neighbors_bytes; }
 
 #if defined(USEARCH_USE_PRAGMA_REGION)
 #pragma endregion
@@ -3799,7 +3792,7 @@ class index_gt {
         metric_at&& metric, compressed_slot_t new_slot, candidates_view_t new_neighbors, value_at&& value,
         level_t level, context_t& context) usearch_noexcept_m {
 
-        top_candidates_t& top = context.top_candidates;
+        top_candidates_t& top_for_refine = context.top_for_refine;
         std::size_t const connectivity_max = level ? config_.connectivity : config_.connectivity_base;
 
         // Reverse links from the neighbors:
@@ -3826,8 +3819,6 @@ class index_gt {
                 continue;
             }
 
-            // In order to keep the memory of 'new_neighbors' not be ovverided, we use the 'top_for_refine' here.
-            top_candidates_t& top_for_refine = context.top_for_refine;
             top_for_refine.clear();
             top_for_refine.insert_reserved({context.measure(value, citerator_at(close_slot), metric), new_slot});
             for (compressed_slot_t successor_slot : close_header)
@@ -3836,8 +3827,8 @@ class index_gt {
 
             // Export the results:
             close_header.clear();
-            candidates_view_t top_view =
-                refine_(metric, connectivity_max, top_for_refine, context, context.computed_distances_in_reverse_refines);
+            candidates_view_t top_view = refine_(metric, connectivity_max, top_for_refine, context,
+                                                 context.computed_distances_in_reverse_refines);
             usearch_assert_m(top_view.size(), "This would lead to isolated nodes");
             for (std::size_t idx = 0; idx != top_view.size(); idx++)
                 close_header.push_back(top_view[idx].slot);


### PR DESCRIPTION
### Related issue
#576

### Proposed Fix
In `context` struct, we can add another member(called `top_for_refine`) of type `top_candidate_t`, which cost very limited memory , actually the capacity is at most 32, because max connectivity is 32 in usearch hnsw algorithm. 

During the execution of `form_reverse_links_`, we use the new added member `top_for_refine` to execute the `refine_` function.

As we add the top_for_refine in the context, it avoid the overhead of repeated construction and deconstruction during the execution of vector index. 