### PR TITLE
Fix key type for Java bindings

### DIFF
--- a/java/cloud/unum/usearch/Index.java
+++ b/java/cloud/unum/usearch/Index.java
@@ -150,7 +150,7 @@ public class Index implements AutoCloseable {
    * @param key    the key associated with the vector
    * @param vector the vector data
    */
-  public void add(int key, float vector[]) {
+  public void add(long key, float vector[]) {
     if (c_ptr == 0) {
       throw new IllegalStateException("Index already closed");
     }
@@ -164,7 +164,7 @@ public class Index implements AutoCloseable {
    * @param count  the number of nearest neighbors to search
    * @return an array of keys of the nearest neighbors
    */
-  public int[] search(float vector[], long count) {
+  public long[] search(float vector[], long count) {
     if (c_ptr == 0) {
       throw new IllegalStateException("Index already closed");
     }
@@ -178,7 +178,7 @@ public class Index implements AutoCloseable {
    * @return the contents of the vector.
    * @throws IllegalArgumentException is key is not available.
    */
-  public float[] get(int key) {
+  public float[] get(long key) {
     if (c_ptr == 0) {
       throw new IllegalStateException("Index already closed");
     }
@@ -243,7 +243,7 @@ public class Index implements AutoCloseable {
    * @return {@code true} if the vector was successfully renamed, {@code false}
    *         otherwise.
    */
-  public boolean rename(int from, int to) {
+  public boolean rename(long from, long to) {
     if (c_ptr == 0) {
       throw new IllegalStateException("Index already closed");
     }
@@ -423,11 +423,11 @@ public class Index implements AutoCloseable {
 
   private static native void c_reserve(long ptr, long capacity);
 
-  private static native void c_add(long ptr, int key, float vector[]);
+  private static native void c_add(long ptr, long key, float vector[]);
 
-  private static native int[] c_search(long ptr, float vector[], long count);
+  private static native long[] c_search(long ptr, float vector[], long count);
 
-  private static native float[] c_get(long ptr, int key);
+  private static native float[] c_get(long ptr, long key);
 
   private static native void c_save(long ptr, String path);
 
@@ -435,7 +435,7 @@ public class Index implements AutoCloseable {
 
   private static native void c_view(long ptr, String path);
 
-  private static native boolean c_remove(long ptr, int key);
+  private static native boolean c_remove(long ptr, long key);
 
-  private static native boolean c_rename(long ptr, int from, int to);
+  private static native boolean c_rename(long ptr, long from, long to);
 }

--- a/java/cloud/unum/usearch/cloud_unum_usearch_Index.h
+++ b/java/cloud/unum/usearch/cloud_unum_usearch_Index.h
@@ -74,26 +74,26 @@ JNIEXPORT void JNICALL Java_cloud_unum_usearch_Index_c_1reserve
 /*
  * Class:     cloud_unum_usearch_Index
  * Method:    c_add
- * Signature: (JI[F)V
+ * Signature: (JJ[F)V
  */
 JNIEXPORT void JNICALL Java_cloud_unum_usearch_Index_c_1add
-  (JNIEnv *, jclass, jlong, jint, jfloatArray);
+  (JNIEnv *, jclass, jlong, jlong, jfloatArray);
 
 /*
  * Class:     cloud_unum_usearch_Index
  * Method:    c_search
- * Signature: (J[FJ)[I
+ * Signature: (J[FJ)[J
  */
-JNIEXPORT jintArray JNICALL Java_cloud_unum_usearch_Index_c_1search
+JNIEXPORT jlongArray JNICALL Java_cloud_unum_usearch_Index_c_1search
   (JNIEnv *, jclass, jlong, jfloatArray, jlong);
 
 /*
  * Class:     cloud_unum_usearch_Index
  * Method:    c_get
- * Signature: (JI)[F
+ * Signature: (JJ)[F
  */
 JNIEXPORT jfloatArray JNICALL Java_cloud_unum_usearch_Index_c_1get
-  (JNIEnv *, jclass, jlong, jint);
+  (JNIEnv *, jclass, jlong, jlong);
 
 /*
  * Class:     cloud_unum_usearch_Index
@@ -122,18 +122,18 @@ JNIEXPORT void JNICALL Java_cloud_unum_usearch_Index_c_1view
 /*
  * Class:     cloud_unum_usearch_Index
  * Method:    c_remove
- * Signature: (JI)Z
+ * Signature: (JJ)Z
  */
 JNIEXPORT jboolean JNICALL Java_cloud_unum_usearch_Index_c_1remove
-  (JNIEnv *, jclass, jlong, jint);
+  (JNIEnv *, jclass, jlong, jlong);
 
 /*
  * Class:     cloud_unum_usearch_Index
  * Method:    c_rename
- * Signature: (JII)Z
+ * Signature: (JJJ)Z
  */
 JNIEXPORT jboolean JNICALL Java_cloud_unum_usearch_Index_c_1rename
-  (JNIEnv *, jclass, jlong, jint, jint);
+  (JNIEnv *, jclass, jlong, jlong, jlong);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Currently, the default native key type of dense index `index_dense_t::vector_key_t` does not match the key type declared for Java bindings. This causes two issues:
* The memcopy in `result::dump_to` overruns the allocated buffer which eventually causes malloc to fail with self-check
* The results returned by search are invalid because when long array is interpreted as int, it causes every second value to be 0 (the current test does not catch this because it checks only one result)

Additionally, this PR fixes a case when the index size is smaller than wanted and eliminates extra copy by dumping results directly to the result array.