### PR TITLE
Test: Add test case for failing `del index[<key>]`

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -142,6 +142,7 @@
     "downcasted",
     "Downcasting",
     "dtype",
+    "dunder",
     "DUSEARCH",
     "emcmake",
     "endregion",

--- a/python/scripts/test_index.py
+++ b/python/scripts/test_index.py
@@ -344,3 +344,22 @@ def test_index_clustering(ndim, metric, quantization, dtype, batch_size):
     clusters: Clustering = index.cluster(min_count=3, max_count=10, threads=threads)
     unique_clusters = set(clusters.matches.keys.flatten().tolist())
     assert len(unique_clusters) >= 3 and len(unique_clusters) <= 10
+
+@pytest.mark.parametrize("batch_size", [32])
+def test_index__delitem__(batch_size):
+    reset_randomness()
+    if batch_size <= 1:
+        return
+
+    ndim = 8
+    index = Index(ndim=ndim, multi=False)
+    keys = np.arange(batch_size)
+    vectors = random_vectors(count=batch_size, ndim=ndim)
+
+    index.add(keys, vectors, threads=threads)
+    assert np.all(index.contains(keys))
+
+    del index[0]
+    
+    assert len(index) == (len(keys) - 1)
+    assert keys[0] not in index

--- a/python/scripts/test_index.py
+++ b/python/scripts/test_index.py
@@ -280,6 +280,7 @@ def test_index_contains_remove_rename(batch_size):
     removed_keys = keys[: batch_size // 2]
     remaining_keys = keys[batch_size // 2 :]
     index.remove(removed_keys)
+    del index[removed_keys] # ! This will trigger the `__delitem__` dunder method
     assert len(index) == (len(keys) - len(removed_keys))
     assert np.sum(index.contains(keys)) == len(remaining_keys)
     assert np.sum(index.count(keys)) == len(remaining_keys)
@@ -344,22 +345,3 @@ def test_index_clustering(ndim, metric, quantization, dtype, batch_size):
     clusters: Clustering = index.cluster(min_count=3, max_count=10, threads=threads)
     unique_clusters = set(clusters.matches.keys.flatten().tolist())
     assert len(unique_clusters) >= 3 and len(unique_clusters) <= 10
-
-@pytest.mark.parametrize("batch_size", [32])
-def test_index__delitem__(batch_size):
-    reset_randomness()
-    if batch_size <= 1:
-        return
-
-    ndim = 8
-    index = Index(ndim=ndim, multi=False)
-    keys = np.arange(batch_size)
-    vectors = random_vectors(count=batch_size, ndim=ndim)
-
-    index.add(keys, vectors, threads=threads)
-    assert np.all(index.contains(keys))
-
-    del index[0]
-    
-    assert len(index) == (len(keys) - 1)
-    assert keys[0] not in index

--- a/python/usearch/index.py
+++ b/python/usearch/index.py
@@ -820,7 +820,7 @@ class Index:
             return self._compiled.remove_many(keys, compact=compact, threads=threads)
 
     def __delitem__(self, keys: KeyOrKeysLike) -> Union[int, np.ndarray]:
-        raise self.remove(keys)
+        return self.remove(keys)
 
     def rename(
         self,


### PR DESCRIPTION
In Python, calling `del index[<key>]` on an `Index` object always raises `TypeError: exceptions must derive from BaseException`.

This PR adds a test case to reproduce the bug.