### PR TITLE
Fix parameter passing issues in bench.cpp

### DIFF
--- a/cpp/bench.cpp
+++ b/cpp/bench.cpp
@@ -514,7 +514,7 @@ struct args_t {
 };
 
 template <typename index_at, typename dataset_at> //
-void run_punned(dataset_at& dataset, args_t const& args, index_config_t config, index_limits_t limits) {
+void run_punned(dataset_at& dataset, args_t const& args, index_dense_config_t config, index_limits_t limits) {
 
     scalar_kind_t quantization = args.quantization();
     std::printf("-- Quantization: %s\n", scalar_kind_name(quantization));


### PR DESCRIPTION
Because the parameters in run_punned are of type index_config_t instead of index_dense_config_t, the expansion_add and expansion_search parameters passed from the command line cannot be correctly passed to the function; they always use default values.