### PR TITLE
Python 3.13t "No-GIL" Builds

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -390,7 +390,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["37", "38", "39", "310", "311", "312", "313"]
+        python-version: ['37', '38', '39', '310', '311', '312', '313', '313t']
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python
@@ -408,6 +408,7 @@ jobs:
         run: cibuildwheel --output-dir wheelhouse
         env:
           CIBW_BUILD: cp${{ matrix.python-version }}-*
+          CIBW_ENABLE: cpython-freethreading # No-GIL 3.13t builds
 
   test_ubuntu_cross_compilation:
     name: Cross Compilation

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -29,7 +29,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Run TinySemVer
-        uses: ashvardanian/tinysemver@v2.0.7
+        uses: ashvardanian/tinysemver@v2.1.1
         with:
           verbose: "true"
           version-file: "VERSION"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Run TinySemVer
-        uses: ashvardanian/tinysemver@v2.0.7
+        uses: ashvardanian/tinysemver@v2.1.1
         with:
           verbose: "true"
           version-file: "VERSION"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -420,12 +420,12 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["37", "38", "39", "310", "311", "312", "313"]
+        python-version: ['37', '38', '39', '310', '311', '312', '313', '313t']
     steps:
       - name: Check out refreshed version
         uses: actions/checkout@v4
         with:
-          ref: "main"
+          ref: 'main'
       - name: Setup Docker
         if: matrix.os == 'ubuntu-22.04'
         uses: crazy-max/ghaction-setup-docker@v1.0.0
@@ -442,6 +442,7 @@ jobs:
         run: cibuildwheel --output-dir wheelhouse
         env:
           CIBW_BUILD: cp${{ matrix.python-version }}-*
+          CIBW_ENABLE: cpython-freethreading # No-GIL 3.13t builds
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
This patch:

- [x] bumps SimSIMD to a more broadly-compatible version.
- [x] bumps CI to provide better versioning & release notes.
- [x] builds no-GIL Python bindings & uploads 'em to PyPi.