### PR TITLE
Feature: Add exact search to rust bindings

### DIFF
--- a/rust/lib.cpp
+++ b/rust/lib.cpp
@@ -37,9 +37,8 @@ scalar_kind_t rust_to_cpp_scalar(ScalarKind value) {
     }
 }
 
-template <typename scalar_at, typename predicate_at = dummy_predicate_t>
-Matches search_(index_dense_t& index, scalar_at const* vec, size_t vec_dims, size_t count, bool exact = false,
-                predicate_at&& predicate = predicate_at{}) {
+template <typename scalar_at>
+Matches search_(index_dense_t& index, scalar_at const* vec, size_t vec_dims, size_t count, bool exact = false) {
     if (vec_dims != index.scalar_words())
         throw std::invalid_argument("Vector length must match index dimensionality");
     Matches matches;
@@ -48,10 +47,26 @@ Matches search_(index_dense_t& index, scalar_at const* vec, size_t vec_dims, siz
     for (size_t i = 0; i != count; ++i)
         matches.keys.push_back(0), matches.distances.push_back(0);
 
-    index_search_config_t config;
-    config.exact = exact;
+    search_result_t result = index.search(vec, count, index_dense_t::any_thread(), exact);
+    result.error.raise();
+    count = result.dump_to(matches.keys.data(), matches.distances.data());
+    matches.keys.truncate(count);
+    matches.distances.truncate(count);
+    return matches;
+}
 
-    search_result_t result = index.filtered_search(vec, count, std::forward<predicate_at>(predicate), config);
+template <typename scalar_at, typename predicate_at>
+Matches filtered_search_(index_dense_t& index, scalar_at const* vec, size_t vec_dims, size_t count,
+                         predicate_at&& predicate) {
+    if (vec_dims != index.scalar_words())
+        throw std::invalid_argument("Vector length must match index dimensionality");
+    Matches matches;
+    matches.keys.reserve(count);
+    matches.distances.reserve(count);
+    for (size_t i = 0; i != count; ++i)
+        matches.keys.push_back(0), matches.distances.push_back(0);
+
+    search_result_t result = index.filtered_search(vec, count, std::forward<predicate_at>(predicate));
     result.error.raise();
     count = result.dump_to(matches.keys.data(), matches.distances.data());
     matches.keys.truncate(count);
@@ -82,23 +97,26 @@ void NativeIndex::add_f16(vector_key_t key, rust::Slice<int16_t const> vec) cons
 void NativeIndex::add_f32(vector_key_t key, rust::Slice<float const> vec) const { add_(*index_, key, vec.data(), vec.size()); }
 void NativeIndex::add_f64(vector_key_t key, rust::Slice<double const> vec) const { add_(*index_, key, vec.data(), vec.size()); }
 
+// Regular approximate search
 Matches NativeIndex::search_b1x8(rust::Slice<uint8_t const> vec, size_t count) const { return search_(*index_, (b1x8_t const*)vec.data(), vec.size(), count, false); }
 Matches NativeIndex::search_i8(rust::Slice<int8_t const> vec, size_t count) const { return search_(*index_, vec.data(), vec.size(), count, false); }
 Matches NativeIndex::search_f16(rust::Slice<int16_t const> vec, size_t count) const { return search_(*index_, (f16_t const*)vec.data(), vec.size(), count, false); }
 Matches NativeIndex::search_f32(rust::Slice<float const> vec, size_t count) const { return search_(*index_, vec.data(), vec.size(), count, false); }
 Matches NativeIndex::search_f64(rust::Slice<double const> vec, size_t count) const { return search_(*index_, vec.data(), vec.size(), count, false); }
 
+// Exact (brute force) search
 Matches NativeIndex::exact_search_b1x8(rust::Slice<uint8_t const> vec, size_t count) const { return search_(*index_, (b1x8_t const*)vec.data(), vec.size(), count, true); }
 Matches NativeIndex::exact_search_i8(rust::Slice<int8_t const> vec, size_t count) const { return search_(*index_, vec.data(), vec.size(), count, true); }
 Matches NativeIndex::exact_search_f16(rust::Slice<int16_t const> vec, size_t count) const { return search_(*index_, (f16_t const*)vec.data(), vec.size(), count, true); }
 Matches NativeIndex::exact_search_f32(rust::Slice<float const> vec, size_t count) const { return search_(*index_, vec.data(), vec.size(), count, true); }
 Matches NativeIndex::exact_search_f64(rust::Slice<double const> vec, size_t count) const { return search_(*index_, vec.data(), vec.size(), count, true); }
 
-Matches NativeIndex::filtered_search_b1x8(rust::Slice<uint8_t const> vec, size_t count, uptr_t metric, uptr_t metric_state) const { return search_(*index_, (b1x8_t const*)vec.data(), vec.size(), count, false, make_predicate(metric, metric_state)); }
-Matches NativeIndex::filtered_search_i8(rust::Slice<int8_t const> vec, size_t count, uptr_t metric, uptr_t metric_state) const { return search_(*index_, vec.data(), vec.size(), count, false, make_predicate(metric, metric_state)); }
-Matches NativeIndex::filtered_search_f16(rust::Slice<int16_t const> vec, size_t count, uptr_t metric, uptr_t metric_state) const { return search_(*index_, (f16_t const*)vec.data(), vec.size(), count, false, make_predicate(metric, metric_state)); }
-Matches NativeIndex::filtered_search_f32(rust::Slice<float const> vec, size_t count, uptr_t metric, uptr_t metric_state) const { return search_(*index_, vec.data(), vec.size(), count, false, make_predicate(metric, metric_state)); }
-Matches NativeIndex::filtered_search_f64(rust::Slice<double const> vec, size_t count, uptr_t metric, uptr_t metric_state) const { return search_(*index_, vec.data(), vec.size(), count, false, make_predicate(metric, metric_state)); }
+// Filtered search (always approximate)
+Matches NativeIndex::filtered_search_b1x8(rust::Slice<uint8_t const> vec, size_t count, uptr_t metric, uptr_t metric_state) const { return filtered_search_(*index_, (b1x8_t const*)vec.data(), vec.size(), count, make_predicate(metric, metric_state)); }
+Matches NativeIndex::filtered_search_i8(rust::Slice<int8_t const> vec, size_t count, uptr_t metric, uptr_t metric_state) const { return filtered_search_(*index_, vec.data(), vec.size(), count, make_predicate(metric, metric_state)); }
+Matches NativeIndex::filtered_search_f16(rust::Slice<int16_t const> vec, size_t count, uptr_t metric, uptr_t metric_state) const { return filtered_search_(*index_, (f16_t const*)vec.data(), vec.size(), count, make_predicate(metric, metric_state)); }
+Matches NativeIndex::filtered_search_f32(rust::Slice<float const> vec, size_t count, uptr_t metric, uptr_t metric_state) const { return filtered_search_(*index_, vec.data(), vec.size(), count, make_predicate(metric, metric_state)); }
+Matches NativeIndex::filtered_search_f64(rust::Slice<double const> vec, size_t count, uptr_t metric, uptr_t metric_state) const { return filtered_search_(*index_, vec.data(), vec.size(), count, make_predicate(metric, metric_state)); }
 
 size_t NativeIndex::get_b1x8(vector_key_t key, rust::Slice<uint8_t> vec) const { if (vec.size() % dimensions()) throw std::invalid_argument("Vector length must match index dimensionality"); return index_->get(key, (b1x8_t*)vec.data(), vec.size() / dimensions()); }
 size_t NativeIndex::get_i8(vector_key_t key, rust::Slice<int8_t> vec) const { if (vec.size() % dimensions()) throw std::invalid_argument("Vector length must match index dimensionality"); return index_->get(key, vec.data(), vec.size() / dimensions()); }

--- a/rust/lib.hpp
+++ b/rust/lib.hpp
@@ -38,6 +38,12 @@ class NativeIndex {
     Matches search_f32(rust::Slice<float const> query, size_t count) const;
     Matches search_f64(rust::Slice<double const> query, size_t count) const;
 
+    Matches exact_search_b1x8(rust::Slice<uint8_t const> query, size_t count) const;
+    Matches exact_search_i8(rust::Slice<int8_t const> query, size_t count) const;
+    Matches exact_search_f16(rust::Slice<int16_t const> query, size_t count) const;
+    Matches exact_search_f32(rust::Slice<float const> query, size_t count) const;
+    Matches exact_search_f64(rust::Slice<double const> query, size_t count) const;
+
     // clang-format off
     Matches filtered_search_b1x8(rust::Slice<uint8_t const> query, size_t count, uptr_t filter_function, uptr_t filter_state) const;
     Matches filtered_search_i8(rust::Slice<int8_t const> query, size_t count, uptr_t filter_function, uptr_t filter_state) const;

--- a/rust/lib.rs
+++ b/rust/lib.rs
@@ -1415,9 +1415,7 @@ mod tests {
     use crate::ffi::ScalarKind;
 
     use crate::b1x8;
-    use crate::f16;
     use crate::new_index;
-    use crate::Distance;
     use crate::Index;
     use crate::Key;
 

--- a/rust/lib.rs
+++ b/rust/lib.rs
@@ -350,6 +350,16 @@ pub mod ffi {
         pub fn search_f32(self: &NativeIndex, query: &[f32], count: usize) -> Result<Matches>;
         pub fn search_f64(self: &NativeIndex, query: &[f64], count: usize) -> Result<Matches>;
 
+        pub fn exact_search_b1x8(self: &NativeIndex, query: &[u8], count: usize)
+            -> Result<Matches>;
+        pub fn exact_search_i8(self: &NativeIndex, query: &[i8], count: usize) -> Result<Matches>;
+        pub fn exact_search_f16(self: &NativeIndex, query: &[i16], count: usize)
+            -> Result<Matches>;
+        pub fn exact_search_f32(self: &NativeIndex, query: &[f32], count: usize)
+            -> Result<Matches>;
+        pub fn exact_search_f64(self: &NativeIndex, query: &[f64], count: usize)
+            -> Result<Matches>;
+
         pub fn filtered_search_b1x8(
             self: &NativeIndex,
             query: &[u8],
@@ -515,7 +525,6 @@ pub struct Index {
 unsafe impl Send for Index {}
 unsafe impl Sync for Index {}
 
-
 impl Default for ffi::IndexOptions {
     fn default() -> Self {
         Self {
@@ -592,6 +601,26 @@ pub trait VectorType {
     where
         Self: Sized;
 
+    /// Performs an exact (brute force) search in the index using the given query vector, returning
+    /// up to `count` closest matches. This search checks all vectors in the index, guaranteeing to find
+    /// the true nearest neighbors, but will be slower especially for large indices.
+    ///
+    /// # Parameters
+    /// - `index`: A reference to the `Index` where the search is to be performed.
+    /// - `query`: A slice representing the query vector.
+    /// - `count`: The maximum number of matches to return.
+    ///
+    /// # Returns
+    /// - `Ok(ffi::Matches)` containing the matches found.
+    /// - `Err(cxx::Exception)` if an error occurred during the search operation.
+    fn exact_search(
+        index: &Index,
+        query: &[Self],
+        count: usize,
+    ) -> Result<ffi::Matches, cxx::Exception>
+    where
+        Self: Sized;
+
     /// Performs a filtered search in the index using a query vector and a custom
     /// filter function, returning up to `count` matches that satisfy the filter.
     ///
@@ -637,12 +666,23 @@ impl VectorType for f32 {
     fn search(index: &Index, query: &[Self], count: usize) -> Result<ffi::Matches, cxx::Exception> {
         index.inner.search_f32(query, count)
     }
+
+    fn exact_search(
+        index: &Index,
+        query: &[Self],
+        count: usize,
+    ) -> Result<ffi::Matches, cxx::Exception> {
+        index.inner.exact_search_f32(query, count)
+    }
+
     fn get(index: &Index, key: Key, vector: &mut [Self]) -> Result<usize, cxx::Exception> {
         index.inner.get_f32(key, vector)
     }
+
     fn add(index: &Index, key: Key, vector: &[Self]) -> Result<(), cxx::Exception> {
         index.inner.add_f32(key, vector)
     }
+
     fn filtered_search<F>(
         index: &Index,
         query: &[Self],
@@ -705,12 +745,23 @@ impl VectorType for i8 {
     fn search(index: &Index, query: &[Self], count: usize) -> Result<ffi::Matches, cxx::Exception> {
         index.inner.search_i8(query, count)
     }
+
+    fn exact_search(
+        index: &Index,
+        query: &[Self],
+        count: usize,
+    ) -> Result<ffi::Matches, cxx::Exception> {
+        index.inner.exact_search_i8(query, count)
+    }
+
     fn get(index: &Index, key: Key, vector: &mut [Self]) -> Result<usize, cxx::Exception> {
         index.inner.get_i8(key, vector)
     }
+
     fn add(index: &Index, key: Key, vector: &[Self]) -> Result<(), cxx::Exception> {
         index.inner.add_i8(key, vector)
     }
+
     fn filtered_search<F>(
         index: &Index,
         query: &[Self],
@@ -772,12 +823,23 @@ impl VectorType for f64 {
     fn search(index: &Index, query: &[Self], count: usize) -> Result<ffi::Matches, cxx::Exception> {
         index.inner.search_f64(query, count)
     }
+
+    fn exact_search(
+        index: &Index,
+        query: &[Self],
+        count: usize,
+    ) -> Result<ffi::Matches, cxx::Exception> {
+        index.inner.exact_search_f64(query, count)
+    }
+
     fn get(index: &Index, key: Key, vector: &mut [Self]) -> Result<usize, cxx::Exception> {
         index.inner.get_f64(key, vector)
     }
+
     fn add(index: &Index, key: Key, vector: &[Self]) -> Result<(), cxx::Exception> {
         index.inner.add_f64(key, vector)
     }
+
     fn filtered_search<F>(
         index: &Index,
         query: &[Self],
@@ -839,12 +901,23 @@ impl VectorType for f16 {
     fn search(index: &Index, query: &[Self], count: usize) -> Result<ffi::Matches, cxx::Exception> {
         index.inner.search_f16(f16::to_i16s(query), count)
     }
+
+    fn exact_search(
+        index: &Index,
+        query: &[Self],
+        count: usize,
+    ) -> Result<ffi::Matches, cxx::Exception> {
+        index.inner.exact_search_f16(f16::to_i16s(query), count)
+    }
+
     fn get(index: &Index, key: Key, vector: &mut [Self]) -> Result<usize, cxx::Exception> {
         index.inner.get_f16(key, f16::to_mut_i16s(vector))
     }
+
     fn add(index: &Index, key: Key, vector: &[Self]) -> Result<(), cxx::Exception> {
         index.inner.add_f16(key, f16::to_i16s(vector))
     }
+
     fn filtered_search<F>(
         index: &Index,
         query: &[Self],
@@ -910,12 +983,23 @@ impl VectorType for b1x8 {
     fn search(index: &Index, query: &[Self], count: usize) -> Result<ffi::Matches, cxx::Exception> {
         index.inner.search_b1x8(b1x8::to_u8s(query), count)
     }
+
+    fn exact_search(
+        index: &Index,
+        query: &[Self],
+        count: usize,
+    ) -> Result<ffi::Matches, cxx::Exception> {
+        index.inner.exact_search_b1x8(b1x8::to_u8s(query), count)
+    }
+
     fn get(index: &Index, key: Key, vector: &mut [Self]) -> Result<usize, cxx::Exception> {
         index.inner.get_b1x8(key, b1x8::to_mut_u8s(vector))
     }
+
     fn add(index: &Index, key: Key, vector: &[Self]) -> Result<(), cxx::Exception> {
         index.inner.add_b1x8(key, b1x8::to_u8s(vector))
     }
+
     fn filtered_search<F>(
         index: &Index,
         query: &[Self],
@@ -1046,6 +1130,26 @@ impl Index {
         count: usize,
     ) -> Result<ffi::Matches, cxx::Exception> {
         T::search(self, query, count)
+    }
+
+    /// Performs exact (brute force) Nearest Neighbors Search for closest vectors to the provided query.
+    /// This search checks all vectors in the index, guaranteeing to find the true nearest neighbors,
+    /// but may be slower for large indices.
+    ///
+    /// # Arguments
+    ///
+    /// * `query` - A slice containing the query vector data.
+    /// * `count` - The maximum number of neighbors to search for.
+    ///
+    /// # Returns
+    ///
+    /// A `Result` containing the matches found.
+    pub fn exact_search<T: VectorType>(
+        self: &Index,
+        query: &[T],
+        count: usize,
+    ) -> Result<ffi::Matches, cxx::Exception> {
+        T::exact_search(self, query, count)
     }
 
     /// Performs k-Approximate Nearest Neighbors (kANN) Search for closest vectors to the provided query
@@ -1672,6 +1776,61 @@ mod tests {
         for distance in matches.distances.iter() {
             assert_ne!(*distance, 0.0);
         }
+    }
+
+    #[test]
+    fn test_exact_search() {
+        use std::collections::HashSet;
+
+        // Create an index with many vectors
+        let options = IndexOptions {
+            dimensions: 4,
+            metric: MetricKind::L2sq,
+            quantization: ScalarKind::F32,
+            ..Default::default()
+        };
+        let index = new_index(&options).unwrap();
+        index.reserve(100).unwrap();
+        // Add 100 vectors to the index
+        for i in 0..100 {
+            let vec = vec![
+                i as f32 * 0.1,
+                (i as f32 * 0.05).sin(),
+                (i as f32 * 0.05).cos(),
+                0.0,
+            ];
+            index.add(i, &vec).unwrap();
+        }
+        // Query vector
+        let query = vec![4.5, 0.0, 1.0, 0.0];
+        // Compare approximate and exact search results
+        let approx_matches = index.search(&query, 10).unwrap();
+        let exact_matches = index.exact_search(&query, 10).unwrap();
+        // Collect the keys from both result sets
+        let approx_keys: HashSet<Key> = approx_matches.keys.iter().cloned().collect();
+        let exact_keys: HashSet<Key> = exact_matches.keys.iter().cloned().collect();
+        // Check that both methods return 10 results
+        assert_eq!(approx_matches.keys.len(), 10);
+        assert_eq!(exact_matches.keys.len(), 10);
+
+        // The exact search should find the true nearest neighbors
+        // Verify that the minimum distance in exact results is <= minimum distance in approximate results
+        assert!(exact_matches.distances[0] <= approx_matches.distances[0]);
+        // The nearest neighbor according to exact search might be different from approximate search
+        println!(
+            "Approximate search first match: key={}, distance={}",
+            approx_matches.keys[0], approx_matches.distances[0]
+        );
+        println!(
+            "Exact search first match: key={}, distance={}",
+            exact_matches.keys[0], exact_matches.distances[0]
+        );
+        // Results from both should be mostly similar, but may differ due to approximation
+        let intersection: HashSet<_> = approx_keys.intersection(&exact_keys).collect();
+        println!(
+            "Number of common results between approximate and exact search: {}",
+            intersection.len()
+        );
     }
 
     #[test]


### PR DESCRIPTION
This brings the functionality in C++ to do brute-force exact searches to the rust binding. 

Since rust doesn't have optional arguments I decided to just add another method `exact_search` instead of changing the `search` method, so this shouldn't be a breaking change. 

I also considered creating a `advanced_search` method with a `SearchOptions` struct so that we could add more options in the future if we want, but decided to just go with the simplest option for now. 