### PR TITLE
Fix initialization of cast_buffer_ in load_from_stream and view.

### DIFF
--- a/include/usearch/index_dense.hpp
+++ b/include/usearch/index_dense.hpp
@@ -1148,7 +1148,9 @@ class index_dense_gt {
 
             config_.multi = head.multi;
             metric_ = metric_t::builtin(head.dimensions, head.kind_metric, head.kind_scalar);
-            cast_buffer_ = cast_buffer_t(available_threads_.size() * metric_.bytes_per_vector());
+            // available_threads_.size() will be updated to old_limits.threads() later in this
+            // method, so use that as the number of threads to prepare for.
+            cast_buffer_ = cast_buffer_t(old_limits.threads() * metric_.bytes_per_vector());
             if (!cast_buffer_)
                 return result.failed("Failed to allocate memory for the casts");
             casts_ = casts_punned_t::make(head.kind_scalar);
@@ -1262,7 +1264,9 @@ class index_dense_gt {
 
             config_.multi = head.multi;
             metric_ = metric_t::builtin(head.dimensions, head.kind_metric, head.kind_scalar);
-            cast_buffer_ = cast_buffer_t(available_threads_.size() * metric_.bytes_per_vector());
+            // available_threads_.size() will be updated to old_limits.threads() later in this
+            // method, so use that as the number of threads to prepare for.
+            cast_buffer_ = cast_buffer_t(old_limits.threads() * metric_.bytes_per_vector());
             if (!cast_buffer_)
                 return result.failed("Failed to allocate memory for the casts");
             casts_ = casts_punned_t::make(head.kind_scalar);


### PR DESCRIPTION
In both `load_from_stream` and `view`, we initialize `cast_buffer_` to hold enough slots for a certain number of threads. This number of threads is currently `available_threads_.size()`. However, `available_threads_` gets replaced later in both methods, specifically updating the number of threads to `old_limits.threads()`. This change makes the initialization statement use that value instead.

This was discussed on discord here: https://discord.com/channels/1063947616615923875/1064496121520590878/1382727527738376283