### PR TITLE
Rename __usearch_raise_runtime_error to usearch_raise_runtime_error to avoid UB

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,7 +116,7 @@ I'd recommend putting the following breakpoints when debugging the code in GDB:
 - `__ubsan::ScopedReport::~ScopedReport` - to catch undefined behavior.
 - `__GI_exit` - to stop at exit points - the end of running any executable.
 - `__builtin_unreachable` - to catch all the places where the code is expected to be unreachable.
-- `__usearch_raise_runtime_error` - for USearch-specific assertions.
+- `usearch_raise_runtime_error` - for USearch-specific assertions.
 
 ### Cross Compilation
 

--- a/cpp/test.cpp
+++ b/cpp/test.cpp
@@ -36,7 +36,7 @@ void __expect(bool must_be_true, char const* file, int line, char const* message
     message = message ? message : "C++ unit test failed";
     char buffer[512];
     std::snprintf(buffer, sizeof(buffer), "%s at %s:%d", message, file, line);
-    __usearch_raise_runtime_error(buffer);
+    usearch_raise_runtime_error(buffer);
 }
 
 template <typename value_at>

--- a/include/usearch/index.hpp
+++ b/include/usearch/index.hpp
@@ -149,15 +149,15 @@
 #else
 #define usearch_assert_m(must_be_true, message)                                                                        \
     if (!(must_be_true)) {                                                                                             \
-        __usearch_raise_runtime_error(message);                                                                        \
+        usearch_raise_runtime_error(message);                                                                          \
     }
 #define usearch_noexcept_m
 #endif
 
 extern "C" {
-/// @brief  Helper function to simplify debugging - trace just one symbol - `__usearch_raise_runtime_error`.
+/// @brief  Helper function to simplify debugging - trace just one symbol - `usearch_raise_runtime_error`.
 ///         Assuming the `extern C` block, the name won't be mangled.
-inline static void __usearch_raise_runtime_error(char const* message) {
+inline static void usearch_raise_runtime_error(char const* message) {
     // On Windows we compile with `/EHc` flag, which specifies that functions
     // with C linkage do not throw C++ exceptions.
 #if !defined(__cpp_exceptions) || defined(USEARCH_DEFINED_WINDOWS)
@@ -2327,7 +2327,7 @@ class index_gt {
         state_result_t failed(error_t message) noexcept { return {std::move(index), std::move(message)}; }
         operator index_gt&&() && {
             if (error)
-                __usearch_raise_runtime_error(error.what());
+                usearch_raise_runtime_error(error.what());
             return std::move(index);
         }
     };

--- a/include/usearch/index_dense.hpp
+++ b/include/usearch/index_dense.hpp
@@ -624,7 +624,7 @@ class index_dense_gt {
         }
         operator index_dense_gt&&() && {
             if (error)
-                __usearch_raise_runtime_error(error.what());
+                usearch_raise_runtime_error(error.what());
             return std::move(index);
         }
     };
@@ -946,7 +946,7 @@ class index_dense_gt {
 
     void reserve(index_limits_t limits) {
         if (!try_reserve(limits))
-            __usearch_raise_runtime_error("failed to reserve memory");
+            usearch_raise_runtime_error("failed to reserve memory");
     }
 
     /**

--- a/include/usearch/index_plugins.hpp
+++ b/include/usearch/index_plugins.hpp
@@ -2588,7 +2588,7 @@ class flat_hash_multi_set_gt {
         // Allocate new memory
         data_ = (char*)allocator_t{}.allocate(other.buckets_ * bytes_per_bucket());
         if (!data_)
-            __usearch_raise_runtime_error("failed memory allocation");
+            usearch_raise_runtime_error("failed memory allocation");
 
         // Copy metadata
         buckets_ = other.buckets_;
@@ -2628,7 +2628,7 @@ class flat_hash_multi_set_gt {
         // Allocate new memory
         data_ = (char*)allocator_t{}.allocate(other.buckets_ * bytes_per_bucket());
         if (!data_)
-            __usearch_raise_runtime_error("failed memory allocation");
+            usearch_raise_runtime_error("failed memory allocation");
 
         // Copy metadata
         buckets_ = other.buckets_;
@@ -3001,7 +3001,7 @@ class flat_hash_multi_set_gt {
 
     void reserve(std::size_t capacity) {
         if (!try_reserve(capacity))
-            __usearch_raise_runtime_error("failed to reserve memory");
+            usearch_raise_runtime_error("failed to reserve memory");
     }
 
     bool try_emplace(element_t const& element) noexcept {


### PR DESCRIPTION
According to https://eel.is/c++draft/lex.name#3, symbols that include double underscores and symbols in the global namespace that start with an underscore are "reserved for use by C++ implementations and shall not be used otherwise". As I understand the standardese, that means it's technically UB to use such symbols. This change renames the symbol to a legal one.

This was discussed on discord here: https://discord.com/channels/1063947616615923875/1064496121520590878/1382728701820801187