### PR TITLE
Fix: Using a custom metric results in a segfault

### DIFF
--- a/rust/lib.rs
+++ b/rust/lib.rs
@@ -674,7 +674,7 @@ impl VectorType for f32 {
         metric: std::boxed::Box<dyn Fn(*const Self, *const Self) -> Distance + Send + Sync>,
     ) -> Result<(), cxx::Exception> {
         // Store the metric function in the Index.
-        type MetricFn = fn(*const f32, *const f32) -> Distance;
+        type MetricFn = Box<dyn Fn(*const f32, *const f32) -> Distance>;
         index.metric_fn = Some(MetricFunction::F32Metric(metric));
 
         // Trampoline is the function that knows how to call the Rust closure.
@@ -684,18 +684,21 @@ impl VectorType for f32 {
         extern "C" fn trampoline(first: usize, second: usize, closure_address: usize) -> Distance {
             let first_ptr = first as *const f32;
             let second_ptr = second as *const f32;
-            let closure: MetricFn = unsafe { std::mem::transmute(closure_address) };
-            closure(first_ptr, second_ptr)
+            let closure: *mut &MetricFn = closure_address as *mut &MetricFn;
+            unsafe { (*closure)(first_ptr, second_ptr) }
         }
 
-        unsafe {
-            let trampoline_fn: usize = std::mem::transmute(trampoline as *const ());
-            let closure_address = match index.metric_fn {
-                Some(MetricFunction::F32Metric(ref metric)) => metric as *const _ as usize,
-                _ => panic!("Expected F32Metric"),
-            };
-            index.inner.change_metric(trampoline_fn, closure_address)
-        }
+        let trampoline_fn: usize = trampoline as *const () as usize;
+        let closure_address = match index.metric_fn {
+            Some(MetricFunction::F32Metric(ref metric)) => {
+                let wrapped = Box::new(metric);
+                Box::into_raw(wrapped)
+            }
+            _ => panic!("Expected F32Metric"),
+        };
+        index
+            .inner
+            .change_metric(trampoline_fn, closure_address as *mut () as usize);
 
         Ok(())
     }
@@ -741,7 +744,7 @@ impl VectorType for i8 {
         metric: std::boxed::Box<dyn Fn(*const Self, *const Self) -> Distance + Send + Sync>,
     ) -> Result<(), cxx::Exception> {
         // Store the metric function in the Index.
-        type MetricFn = fn(*const i8, *const i8) -> Distance;
+        type MetricFn = Box<dyn Fn(*const i8, *const i8) -> Distance>;
         index.metric_fn = Some(MetricFunction::I8Metric(metric));
 
         // Trampoline is the function that knows how to call the Rust closure.
@@ -751,18 +754,21 @@ impl VectorType for i8 {
         extern "C" fn trampoline(first: usize, second: usize, closure_address: usize) -> Distance {
             let first_ptr = first as *const i8;
             let second_ptr = second as *const i8;
-            let closure: MetricFn = unsafe { std::mem::transmute(closure_address) };
-            closure(first_ptr, second_ptr)
+            let closure: *mut &MetricFn = closure_address as *mut &MetricFn;
+            unsafe { (*closure)(first_ptr, second_ptr) }
         }
 
-        unsafe {
-            let trampoline_fn: usize = std::mem::transmute(trampoline as *const ());
-            let closure_address = match index.metric_fn {
-                Some(MetricFunction::I8Metric(ref metric)) => metric as *const _ as usize,
-                _ => panic!("Expected I8Metric"),
-            };
-            index.inner.change_metric(trampoline_fn, closure_address)
-        }
+        let trampoline_fn: usize = trampoline as *const () as usize;
+        let closure_address = match index.metric_fn {
+            Some(MetricFunction::I8Metric(ref metric)) => {
+                let wrapped = Box::new(metric);
+                Box::into_raw(wrapped)
+            }
+            _ => panic!("Expected I8Metric"),
+        };
+        index
+            .inner
+            .change_metric(trampoline_fn, closure_address as *mut () as usize);
 
         Ok(())
     }
@@ -808,7 +814,7 @@ impl VectorType for f64 {
         metric: std::boxed::Box<dyn Fn(*const Self, *const Self) -> Distance + Send + Sync>,
     ) -> Result<(), cxx::Exception> {
         // Store the metric function in the Index.
-        type MetricFn = fn(*const f64, *const f64) -> Distance;
+        type MetricFn = Box<dyn Fn(*const f64, *const f64) -> Distance>;
         index.metric_fn = Some(MetricFunction::F64Metric(metric));
 
         // Trampoline is the function that knows how to call the Rust closure.
@@ -818,18 +824,21 @@ impl VectorType for f64 {
         extern "C" fn trampoline(first: usize, second: usize, closure_address: usize) -> Distance {
             let first_ptr = first as *const f64;
             let second_ptr = second as *const f64;
-            let closure: MetricFn = unsafe { std::mem::transmute(closure_address) };
-            closure(first_ptr, second_ptr)
+            let closure: *mut &MetricFn = closure_address as *mut &MetricFn;
+            unsafe { (*closure)(first_ptr, second_ptr) }
         }
 
-        unsafe {
-            let trampoline_fn: usize = std::mem::transmute(trampoline as *const ());
-            let closure_address = match index.metric_fn {
-                Some(MetricFunction::F64Metric(ref metric)) => metric as *const _ as usize,
-                _ => panic!("Expected F64Metric"),
-            };
-            index.inner.change_metric(trampoline_fn, closure_address)
-        }
+        let trampoline_fn: usize = trampoline as *const () as usize;
+        let closure_address = match index.metric_fn {
+            Some(MetricFunction::I8Metric(ref metric)) => {
+                let wrapped = Box::new(metric);
+                Box::into_raw(wrapped)
+            }
+            _ => panic!("Expected F64Metric"),
+        };
+        index
+            .inner
+            .change_metric(trampoline_fn, closure_address as *mut () as usize);
 
         Ok(())
     }
@@ -879,7 +888,7 @@ impl VectorType for f16 {
         metric: std::boxed::Box<dyn Fn(*const Self, *const Self) -> Distance + Send + Sync>,
     ) -> Result<(), cxx::Exception> {
         // Store the metric function in the Index.
-        type MetricFn = fn(*const f16, *const f16) -> Distance;
+        type MetricFn = Box<dyn Fn(*const f16, *const f16) -> Distance>;
         index.metric_fn = Some(MetricFunction::F16Metric(metric));
 
         // Trampoline is the function that knows how to call the Rust closure.
@@ -889,18 +898,21 @@ impl VectorType for f16 {
         extern "C" fn trampoline(first: usize, second: usize, closure_address: usize) -> Distance {
             let first_ptr = first as *const f16;
             let second_ptr = second as *const f16;
-            let closure: MetricFn = unsafe { std::mem::transmute(closure_address) };
-            closure(first_ptr, second_ptr)
+            let closure: *mut &MetricFn = closure_address as *mut &MetricFn;
+            unsafe { (*closure)(first_ptr, second_ptr) }
         }
 
-        unsafe {
-            let trampoline_fn: usize = std::mem::transmute(trampoline as *const ());
-            let closure_address = match index.metric_fn {
-                Some(MetricFunction::F16Metric(ref metric)) => metric as *const _ as usize,
-                _ => panic!("Expected F16Metric"),
-            };
-            index.inner.change_metric(trampoline_fn, closure_address)
-        }
+        let trampoline_fn: usize = trampoline as *const () as usize;
+        let closure_address = match index.metric_fn {
+            Some(MetricFunction::I8Metric(ref metric)) => {
+                let wrapped = Box::new(metric);
+                Box::into_raw(wrapped)
+            }
+            _ => panic!("Expected F16Metric"),
+        };
+        index
+            .inner
+            .change_metric(trampoline_fn, closure_address as *mut () as usize);
 
         Ok(())
     }
@@ -950,7 +962,7 @@ impl VectorType for b1x8 {
         metric: std::boxed::Box<dyn Fn(*const Self, *const Self) -> Distance + Send + Sync>,
     ) -> Result<(), cxx::Exception> {
         // Store the metric function in the Index.
-        type MetricFn = fn(*const b1x8, *const b1x8) -> Distance;
+        type MetricFn = Box<dyn Fn(*const b1x8, *const b1x8) -> Distance>;
         index.metric_fn = Some(MetricFunction::B1X8Metric(metric));
 
         // Trampoline is the function that knows how to call the Rust closure.
@@ -960,18 +972,21 @@ impl VectorType for b1x8 {
         extern "C" fn trampoline(first: usize, second: usize, closure_address: usize) -> Distance {
             let first_ptr = first as *const b1x8;
             let second_ptr = second as *const b1x8;
-            let closure: MetricFn = unsafe { std::mem::transmute(closure_address) };
-            closure(first_ptr, second_ptr)
+            let closure: *mut &MetricFn = closure_address as *mut &MetricFn;
+            unsafe { (*closure)(first_ptr, second_ptr) }
         }
 
-        unsafe {
-            let trampoline_fn: usize = std::mem::transmute(trampoline as *const ());
-            let closure_address = match index.metric_fn {
-                Some(MetricFunction::B1X8Metric(ref metric)) => metric as *const _ as usize,
-                _ => panic!("Expected B1X8Metric"),
-            };
-            index.inner.change_metric(trampoline_fn, closure_address)
-        }
+        let trampoline_fn: usize = trampoline as *const () as usize;
+        let closure_address = match index.metric_fn {
+            Some(MetricFunction::I8Metric(ref metric)) => {
+                let wrapped = Box::new(metric);
+                Box::into_raw(wrapped)
+            }
+            _ => panic!("Expected F1X8Metric"),
+        };
+        index
+            .inner
+            .change_metric(trampoline_fn, closure_address as *mut () as usize);
 
         Ok(())
     }
@@ -1695,6 +1710,9 @@ mod tests {
                 + (a_slice[1] - b_slice[1]).abs() * second_factor
         });
         index.change_metric(stateful_distance);
+        
+        let another_vector: [f32; 2] = [1.0, 0.0];
+        index.add(2, &vector).unwrap();
     }
 
     #[test]


### PR DESCRIPTION
Fixes https://github.com/unum-cloud/usearch/issues/629

Add another vector to Index after changing metric in the test.

Afterwards, It would be wise to write tests for each VectorType since they have different implementations.
Anyway, the fix has been tested on all of them.