### PR TITLE
Test covering `golang.NewIndex` SEGFAULTs

### DIFF
--- a/golang/lib_test.go
+++ b/golang/lib_test.go
@@ -258,7 +258,7 @@ func TestNewIndex(t *testing.T) {
 
 				err = index.Reserve(dim)
 				if err != nil {
-					t.Fatalf("Failed to create index: %s", err)
+					t.Fatalf("Failed to reserve index: %s", err)
 				}
 
 				vec := make([]float32, dim)


### PR DESCRIPTION
Add a test case tries to reproduce the golang.NewIndex bug.