### PR TITLE
Multi-threading Usability in Python & JavaScript

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -163,15 +163,15 @@ The compilation settings are controlled by the `setup.py` and are independent fr
 To install USearch locally using `uv`:
 
 ```sh
-uv venv --python 3.11           # or your preferred Python version
-source .venv/bin/activate       # to activate the virtual environment
-uv pip install -e .             # to build locally from source
+uv venv --python 3.11                   # or your preferred Python version
+source .venv/bin/activate               # to activate the virtual environment
+uv pip install -e . --force-reinstall   # to build locally from source
 ```
 
 Or using `pip` directly:
 
 ```sh
-pip install -e .
+pip install -e . --force-reinstall
 ```
 
 For testing USearch uses PyTest, which is pre-configured in `pyproject.toml`.

--- a/include/usearch/index.hpp
+++ b/include/usearch/index.hpp
@@ -1751,6 +1751,9 @@ class memory_mapped_file_t {
     {
     }
 
+    memory_mapped_file_t(memory_mapped_file_t const&) = delete;
+    memory_mapped_file_t& operator=(memory_mapped_file_t const&) = delete;
+
     memory_mapped_file_t(byte_t* data, std::size_t length) noexcept : ptr_(data), length_(length) {}
 
     memory_mapped_file_t& operator=(memory_mapped_file_t&& other) noexcept {

--- a/javascript/lib.cpp
+++ b/javascript/lib.cpp
@@ -388,7 +388,7 @@ Napi::Value exactSearch(Napi::CallbackInfo const& ctx) {
         return env.Null();
     }
 
-    executor_default_t executor(threads);
+    executor_default_t executor{threads};
     exact_search_t search;
 
     // Performing the exact search.

--- a/javascript/usearch.test.js
+++ b/javascript/usearch.test.js
@@ -2,28 +2,28 @@ const nodeTest = require('node:test');
 const realTest = nodeTest.test; // the original function
 
 function loggedTest(name, options, fn) {
-    // The API has two call signatures:
-    //   test(name, fn)
-    //   test(name, options, fn)
-    if (typeof options === 'function') {
-        fn = options;
-        options = undefined;
+  // The API has two call signatures:
+  //   test(name, fn)
+  //   test(name, options, fn)
+  if (typeof options === 'function') {
+    fn = options;
+    options = undefined;
+  }
+
+  // Wrap the body so we can log before / after
+  const wrapped = async (t) => {
+    console.log('▶', name);
+    try {
+      await fn(t); // run the user’s test
+      console.log('✓', name);
+    } catch (err) {
+      console.log('✖', name);
+      throw err; // re-throw so the runner records the failure
     }
+  };
 
-    // Wrap the body so we can log before / after
-    const wrapped = async (t) => {
-        console.log('▶', name);
-        try {
-            await fn(t); // run the user’s test
-            console.log('✓', name);
-        } catch (err) {
-            console.log('✖', name);
-            throw err; // re-throw so the runner records the failure
-        }
-    };
-
-    // Delegate back to the real test() with the same options
-    return options ? realTest(name, options, wrapped) : realTest(name, wrapped);
+  // Delegate back to the real test() with the same options
+  return options ? realTest(name, options, wrapped) : realTest(name, wrapped);
 }
 
 // Replace both the export and the global the runner puts on each module
@@ -37,304 +37,354 @@ const path = require('node:path');
 const usearch = require('./dist/cjs/usearch.js');
 
 function assertAlmostEqual(actual, expected, tolerance = 1e-6) {
-    const lowerBound = expected - tolerance;
-    const upperBound = expected + tolerance;
-    assert(
-        actual >= lowerBound && actual <= upperBound,
-        `Expected ${actual} to be almost equal to ${expected}`
-    );
+  const lowerBound = expected - tolerance;
+  const upperBound = expected + tolerance;
+  assert(
+    actual >= lowerBound && actual <= upperBound,
+    `Expected ${actual} to be almost equal to ${expected}`
+  );
 }
 
+const THREADS = 2;
+
 test('Single-entry operations', async (t) => {
-    await t.test('index info', () => {
-        const index = new usearch.Index(2, 'l2sq');
+  await t.test('index info', () => {
+    const index = new usearch.Index(2, 'l2sq');
 
-        assert.equal(index.connectivity(), 16, 'connectivity should be 16');
-        assert.equal(index.dimensions(), 2, 'dimensions should be 2');
-        assert.equal(index.size(), 0, 'initial size should be 0');
-    });
+    assert.equal(index.connectivity(), 16, 'connectivity should be 16');
+    assert.equal(index.dimensions(), 2, 'dimensions should be 2');
+    assert.equal(index.size(), 0, 'initial size should be 0');
+  });
 
-    await t.test('add', () => {
-        const index = new usearch.Index(2, 'l2sq');
+  await t.test('add', () => {
+    const index = new usearch.Index(2, 'l2sq');
 
-        index.add(15n, new Float32Array([10, 20]));
-        index.add(16n, new Float32Array([10, 25]));
+    index.add(15n, new Float32Array([10, 20]));
+    index.add(16n, new Float32Array([10, 25]));
 
-        assert.equal(index.size(), 2, 'size after adding elements should be 2');
-        assert.equal(
-            index.contains(15),
-            true,
-            'entry must be present after insertion'
-        );
+    assert.equal(index.size(), 2, 'size after adding elements should be 2');
+    assert.equal(
+      index.contains(15),
+      true,
+      'entry must be present after insertion'
+    );
 
-        const results = index.search(new Float32Array([13, 14]), 2);
+    const results = index.search(new Float32Array([13, 14]), 2);
 
-        assert.deepEqual(
-            results.keys,
-            new BigUint64Array([15n, 16n]),
-            'keys should be 15 and 16'
-        );
-        assert.deepEqual(
-            results.distances,
-            new Float32Array([45, 130]),
-            'distances should be 45 and 130'
-        );
-    });
+    assert.deepEqual(
+      results.keys,
+      new BigUint64Array([15n, 16n]),
+      'keys should be 15 and 16'
+    );
+    assert.deepEqual(
+      results.distances,
+      new Float32Array([45, 130]),
+      'distances should be 45 and 130'
+    );
+  });
 
-    await t.test('remove', () => {
-        const index = new usearch.Index(2, 'l2sq');
+  await t.test('remove', () => {
+    const index = new usearch.Index(2, 'l2sq');
 
-        index.add(15n, new Float32Array([10, 20]));
-        index.add(16n, new Float32Array([10, 25]));
-        index.add(25n, new Float32Array([20, 40]));
-        index.add(26n, new Float32Array([20, 45]));
+    index.add(15n, new Float32Array([10, 20]));
+    index.add(16n, new Float32Array([10, 25]));
+    index.add(25n, new Float32Array([20, 40]));
+    index.add(26n, new Float32Array([20, 45]));
 
-        assert.equal(index.remove(15n), 1);
+    assert.equal(index.remove(15n), 1);
 
-        assert.equal(
-            index.size(),
-            3,
-            'size after removing elements should be 3'
-        );
-        assert.equal(
-            index.contains(15),
-            false,
-            'entry must be absent after insertion'
-        );
+    assert.equal(index.size(), 3, 'size after removing elements should be 3');
+    assert.equal(
+      index.contains(15),
+      false,
+      'entry must be absent after insertion'
+    );
 
-        const results = index.search(new Float32Array([13, 14]), 2);
+    const results = index.search(new Float32Array([13, 14]), 2);
 
-        assert.deepEqual(
-            results.keys,
-            new BigUint64Array([16n, 25n]),
-            'keys should not include 15'
-        );
-    });
+    assert.deepEqual(
+      results.keys,
+      new BigUint64Array([16n, 25n]),
+      'keys should not include 15'
+    );
+  });
 });
 
 test('Batch operations', async (t) => {
-    await t.test('add', () => {
-        const indexBatch = new usearch.Index(2, 'l2sq');
+  await t.test('add', () => {
+    const indexBatch = new usearch.Index(2, 'l2sq');
 
-        const keys = [15n, 16n];
-        const vectors = [
-            new Float32Array([10, 20]),
-            new Float32Array([10, 25]),
-        ];
+    const keys = [15n, 16n];
+    const vectors = [new Float32Array([10, 20]), new Float32Array([10, 25])];
 
-        indexBatch.add(keys, vectors);
-        assert.equal(
-            indexBatch.size(),
-            2,
-            'size after adding batch should be 2'
-        );
+    indexBatch.add(keys, vectors);
+    assert.equal(indexBatch.size(), 2, 'size after adding batch should be 2');
 
-        const results = indexBatch.search(new Float32Array([13, 14]), 2);
+    const results = indexBatch.search(new Float32Array([13, 14]), 2);
 
-        assert.deepEqual(
-            results.keys,
-            new BigUint64Array([15n, 16n]),
-            'keys should be 15 and 16'
-        );
-        assert.deepEqual(
-            results.distances,
-            new Float32Array([45, 130]),
-            'distances should be 45 and 130'
-        );
-    });
+    assert.deepEqual(
+      results.keys,
+      new BigUint64Array([15n, 16n]),
+      'keys should be 15 and 16'
+    );
+    assert.deepEqual(
+      results.distances,
+      new Float32Array([45, 130]),
+      'distances should be 45 and 130'
+    );
+  });
 
-    await t.test('remove', () => {
-        const indexBatch = new usearch.Index(2, 'l2sq');
+  await t.test('remove', () => {
+    const indexBatch = new usearch.Index(2, 'l2sq');
 
-        const keys = [15n, 16n, 25n, 26n];
-        const vectors = [
-            new Float32Array([10, 20]),
-            new Float32Array([10, 25]),
-            new Float32Array([20, 40]),
-            new Float32Array([20, 45]),
-        ];
-        indexBatch.add(keys, vectors);
+    const keys = [15n, 16n, 25n, 26n];
+    const vectors = [
+      new Float32Array([10, 20]),
+      new Float32Array([10, 25]),
+      new Float32Array([20, 40]),
+      new Float32Array([20, 45]),
+    ];
+    indexBatch.add(keys, vectors);
 
-        assert.deepEqual(indexBatch.remove([15n, 25n]), [1, 1]);
-        assert.equal(
-            indexBatch.size(),
-            2,
-            'size after removing batch should be 2'
-        );
+    assert.deepEqual(indexBatch.remove([15n, 25n]), [1, 1]);
+    assert.equal(indexBatch.size(), 2, 'size after removing batch should be 2');
 
-        const results = indexBatch.search(new Float32Array([13, 14]), 2);
+    const results = indexBatch.search(new Float32Array([13, 14]), 2);
 
-        assert.deepEqual(
-            results.keys,
-            new BigUint64Array([16n, 26n]),
-            'keys should not include 15 and 25'
-        );
-    });
+    assert.deepEqual(
+      results.keys,
+      new BigUint64Array([16n, 26n]),
+      'keys should not include 15 and 25'
+    );
+  });
 });
 
 test('Expected results', () => {
+  const index = new usearch.Index({
+    metric: 'l2sq',
+    connectivity: 16,
+    dimensions: 3,
+  });
+  index.add(42n, new Float32Array([0.2, 0.6, 0.4]));
+  const results = index.search(new Float32Array([0.2, 0.6, 0.4]), 10);
+
+  assert.equal(index.size(), 1);
+  assert.deepEqual(results.keys, new BigUint64Array([42n]));
+  assertAlmostEqual(results.distances[0], new Float32Array([0]));
+});
+
+test('Multithread search returns same results', () => {
+  const index = new usearch.Index({
+    metric: 'l2sq',
+    connectivity: 16,
+    dimensions: 3,
+  });
+  index.add(42n, new Float32Array([0.2, 0.6, 0.4]));
+  assert.equal(index.size(), 1);
+
+  const results_1 = index.search(new Float32Array([0.2, 0.6, 0.4]), 10, 0);
+  const results_2 = index.search(
+    new Float32Array([0.2, 0.6, 0.4]),
+    10,
+    THREADS
+  );
+
+  assert.deepEqual(results_1.keys, results_2.keys);
+  assertAlmostEqual(results_1.distances, results_2.distances);
+});
+
+test('Exact search', async (t) => {
+  const dataset = [
+    new Float32Array([0.2, 0.6, 0.4]),
+    new Float32Array([0.6, 0.6, 0.4]),
+  ];
+  const queries = new Float32Array([0.2, 0.6, 0.4]);
+  const dimensions = 3;
+  const count = 2;
+  const metric = 'l2sq';
+
+  await t.test('Single core search', () => {
+    const result = usearch.exactSearch(
+      dataset,
+      queries,
+      dimensions,
+      count,
+      metric,
+      1 // threads
+    );
+
+    assert.deepEqual(result.keys, new BigUint64Array([0n, 1n]));
+    assertAlmostEqual(new Float32Array([0]), result.distances[0]);
+    assertAlmostEqual(new Float32Array([0.16]), result.distances[1]);
+  });
+
+  await t.test('Multithreaded search', () => {
+    const result = usearch.exactSearch(
+      dataset,
+      queries,
+      dimensions,
+      count,
+      metric,
+      THREADS // threads
+    );
+
+    assert.deepEqual(result.keys, new BigUint64Array([0n, 1n]));
+    assertAlmostEqual(new Float32Array([0]), result.distances[0]);
+    assertAlmostEqual(new Float32Array([0.16]), result.distances[1]);
+  });
+});
+
+test('Expected count()', async (t) => {
+  const index = new usearch.Index({
+    metric: 'l2sq',
+    connectivity: 16,
+    dimensions: 3,
+  });
+  index.add(
+    [42n, 43n],
+    [new Float32Array([0.2, 0.6, 0.4]), new Float32Array([0.2, 0.6, 0.4])]
+  );
+
+  await t.test('Argument is a number', () => {
+    assert.equal(1, index.count(43n));
+  });
+  await t.test('Argument is a number (does not exist)', () => {
+    assert.equal(0, index.count(44n));
+  });
+  await t.test('Argument is an array', () => {
+    assert.deepEqual([1, 1, 0], index.count([42n, 43n, 44n]));
+  });
+});
+
+test('Operations with invalid values', () => {
+  const indexBatch = new usearch.Index(2, 'l2sq');
+
+  const keys = [NaN, 16n];
+  const vectors = [new Float32Array([10, 30]), new Float32Array([1, 5])];
+
+  // All keys must be positive integers or bigints
+  assert.throws(() => indexBatch.add(keys, vectors));
+
+  // Vectors must be a TypedArray or an array of arrays
+  assert.throws(() => indexBatch.search(NaN, 2));
+});
+
+test('Invalid operations', async (t) => {
+  await t.test('Add the same keys', () => {
     const index = new usearch.Index({
-        metric: 'l2sq',
-        connectivity: 16,
-        dimensions: 3,
+      metric: 'l2sq',
+      connectivity: 16,
+      dimensions: 3,
     });
     index.add(42n, new Float32Array([0.2, 0.6, 0.4]));
-    const results = index.search(new Float32Array([0.2, 0.6, 0.4]), 10);
+    assert.throws(() => index.add(42n, new Float32Array([0.2, 0.6, 0.4])));
+  });
+
+  await t.test('Batch add containing the same key', () => {
+    const index = new usearch.Index({
+      metric: 'l2sq',
+      connectivity: 16,
+      dimensions: 3,
+    });
+    index.add(42n, new Float32Array([0.2, 0.6, 0.4]));
+    assert.throws(() => {
+      index.add(
+        [41n, 42n, 43n],
+        [
+          [0.1, 0.6, 0.4],
+          [0.2, 0.6, 0.4],
+          [0.3, 0.6, 0.4],
+        ]
+      );
+    });
+  });
+});
+
+test('Serialization', async (t) => {
+  const indexPath = path.join(os.tmpdir(), 'usearch.test.index');
+
+  t.beforeEach(() => {
+    const index = new usearch.Index({
+      metric: 'l2sq',
+      connectivity: 16,
+      dimensions: 3,
+    });
+    index.add(42n, new Float32Array([0.2, 0.6, 0.4]));
+    index.save(indexPath);
+  });
+
+  t.afterEach(() => {
+    fs.unlinkSync(indexPath);
+  });
+
+  await t.test('load', () => {
+    const index = new usearch.Index({
+      metric: 'l2sq',
+      connectivity: 16,
+      dimensions: 3,
+    });
+    index.load(indexPath);
+    const results = index.search(
+      new Float32Array([0.2, 0.6, 0.4]),
+      10,
+      THREADS
+    );
 
     assert.equal(index.size(), 1);
     assert.deepEqual(results.keys, new BigUint64Array([42n]));
     assertAlmostEqual(results.distances[0], new Float32Array([0]));
-});
+  });
 
-test('Expected count()', async (t) => {
-    const index = new usearch.Index({
+  // todo: Skip as the test fails only on windows.
+  // The following error in afterEach().
+  // `error: "EBUSY: resource busy or locked, unlink`
+  await t.test(
+    'view: Read data',
+    { skip: process.platform === 'win32' },
+    () => {
+      const index = new usearch.Index({
         metric: 'l2sq',
         connectivity: 16,
         dimensions: 3,
-    });
-    index.add(
-        [42n, 43n],
-        [new Float32Array([0.2, 0.6, 0.4]), new Float32Array([0.2, 0.6, 0.4])]
-    );
+      });
+      index.view(indexPath);
+      const results = index.search(new Float32Array([0.2, 0.6, 0.4]), 10);
 
-    await t.test('Argument is a number', () => {
-        assert.equal(1, index.count(43n));
-    });
-    await t.test('Argument is a number (does not exist)', () => {
-        assert.equal(0, index.count(44n));
-    });
-    await t.test('Argument is an array', () => {
-        assert.deepEqual([1, 1, 0], index.count([42n, 43n, 44n]));
-    });
-});
+      assert.equal(index.size(), 1);
+      assert.deepEqual(results.keys, new BigUint64Array([42n]));
+      assertAlmostEqual(results.distances[0], new Float32Array([0]));
+    }
+  );
 
-test('Operations with invalid values', () => {
-    const indexBatch = new usearch.Index(2, 'l2sq');
+  await t.test(
+    'view: Invalid operations: add',
+    { skip: process.platform === 'win32' },
+    () => {
+      const index = new usearch.Index({
+        metric: 'l2sq',
+        connectivity: 16,
+        dimensions: 3,
+      });
+      index.view(indexPath);
 
-    const keys = [NaN, 16n];
-    const vectors = [new Float32Array([10, 30]), new Float32Array([1, 5])];
+      // Can't add to an immutable index
+      assert.throws(() => index.add(43n, new Float32Array([0.2, 0.6, 0.4])));
+    }
+  );
 
-    // All keys must be positive integers or bigints
-    assert.throws(() => indexBatch.add(keys, vectors));
+  await t.test(
+    'view: Invalid operations: remove',
+    { skip: process.platform === 'win32' },
+    () => {
+      const index = new usearch.Index({
+        metric: 'l2sq',
+        connectivity: 16,
+        dimensions: 3,
+      });
+      index.view(indexPath);
 
-    // Vectors must be a TypedArray or an array of arrays
-    assert.throws(() => indexBatch.search(NaN, 2));
-});
-
-test('Invalid operations', async (t) => {
-    await t.test('Add the same keys', () => {
-        const index = new usearch.Index({
-            metric: 'l2sq',
-            connectivity: 16,
-            dimensions: 3,
-        });
-        index.add(42n, new Float32Array([0.2, 0.6, 0.4]));
-        assert.throws(() => index.add(42n, new Float32Array([0.2, 0.6, 0.4])));
-    });
-
-    await t.test('Batch add containing the same key', () => {
-        const index = new usearch.Index({
-            metric: 'l2sq',
-            connectivity: 16,
-            dimensions: 3,
-        });
-        index.add(42n, new Float32Array([0.2, 0.6, 0.4]));
-        assert.throws(() => {
-            index.add(
-                [41n, 42n, 43n],
-                [
-                    [0.1, 0.6, 0.4],
-                    [0.2, 0.6, 0.4],
-                    [0.3, 0.6, 0.4],
-                ]
-            );
-        });
-    });
-});
-
-test('Serialization', async (t) => {
-    const indexPath = path.join(os.tmpdir(), 'usearch.test.index');
-
-    t.beforeEach(() => {
-        const index = new usearch.Index({
-            metric: 'l2sq',
-            connectivity: 16,
-            dimensions: 3,
-        });
-        index.add(42n, new Float32Array([0.2, 0.6, 0.4]));
-        index.save(indexPath);
-    });
-
-    t.afterEach(() => {
-        fs.unlinkSync(indexPath);
-    });
-
-    await t.test('load', () => {
-        const index = new usearch.Index({
-            metric: 'l2sq',
-            connectivity: 16,
-            dimensions: 3,
-        });
-        index.load(indexPath);
-        const results = index.search(new Float32Array([0.2, 0.6, 0.4]), 10);
-
-        assert.equal(index.size(), 1);
-        assert.deepEqual(results.keys, new BigUint64Array([42n]));
-        assertAlmostEqual(results.distances[0], new Float32Array([0]));
-    });
-
-    // todo: Skip as the test fails only on windows.
-    // The following error in afterEach().
-    // `error: "EBUSY: resource busy or locked, unlink`
-    await t.test(
-        'view: Read data',
-        { skip: process.platform === 'win32' },
-        () => {
-            const index = new usearch.Index({
-                metric: 'l2sq',
-                connectivity: 16,
-                dimensions: 3,
-            });
-            index.view(indexPath);
-            const results = index.search(new Float32Array([0.2, 0.6, 0.4]), 10);
-
-            assert.equal(index.size(), 1);
-            assert.deepEqual(results.keys, new BigUint64Array([42n]));
-            assertAlmostEqual(results.distances[0], new Float32Array([0]));
-        }
-    );
-
-    await t.test(
-        'view: Invalid operations: add',
-        { skip: process.platform === 'win32' },
-        () => {
-            const index = new usearch.Index({
-                metric: 'l2sq',
-                connectivity: 16,
-                dimensions: 3,
-            });
-            index.view(indexPath);
-
-            // Can't add to an immutable index
-            assert.throws(() =>
-                index.add(43n, new Float32Array([0.2, 0.6, 0.4]))
-            );
-        }
-    );
-
-    await t.test(
-        'view: Invalid operations: remove',
-        { skip: process.platform === 'win32' },
-        () => {
-            const index = new usearch.Index({
-                metric: 'l2sq',
-                connectivity: 16,
-                dimensions: 3,
-            });
-            index.view(indexPath);
-
-            // Can't remove from an immutable index
-            assert.throws(() => index.remove(42n));
-        }
-    );
+      // Can't remove from an immutable index
+      assert.throws(() => index.remove(42n));
+    }
+  );
 });

--- a/javascript/usearch.ts
+++ b/javascript/usearch.ts
@@ -562,15 +562,16 @@ type NumberArrayConstructor =
  * const dimensions = 2; // The number of elements in each vector.
  * const count = 1; // The number of nearest neighbors to return for each query.
  * const metric = MetricKind.IP; // Using the Inner Product distance metric.
+ * const threads = 0; // How many threads to use to perform the search.
  *
- * const result = exactSearch(dataset, queries, dimensions, count, metric);
+ * const result = exactSearch(dataset, queries, dimensions, count, metric, threads);
  * // result might be:
  * // {
  * //    keys: BigUint64Array [ 1n ],
  * //    distances: Float32Array [ some_value ],
  * // }
  */
-function exactSearch(
+export function exactSearch(
   dataset: VectorOrMatrix,
   queries: VectorOrMatrix,
   dimensions: number,

--- a/python/lib.cpp
+++ b/python/lib.cpp
@@ -842,8 +842,6 @@ static py::dict index_metadata(index_dense_metadata_result_t const& meta) {
 
 // clang-format off
 template <typename index_at> void save_index_to_path(index_at const& index, std::string const& path, progress_func_t const& progress) { index.save(path.c_str(), {}, progress_t{progress}).error.raise(); }
-template <typename index_at> void load_index_from_path(index_at& index, std::string const& path, progress_func_t const& progress) { index.load(path.c_str(), {}, progress_t{progress}).error.raise(); }
-template <typename index_at> void view_index_from_path(index_at& index, std::string const& path, progress_func_t const& progress) { index.view(path.c_str(), 0, {}, progress_t{progress}).error.raise(); }
 template <typename index_at> void reset_index(index_at& index) { index.reset(); }
 template <typename index_at> void clear_index(index_at& index) { index.clear(); }
 template <typename index_at> std::size_t max_level(index_at const &index) { return index.max_level(); }
@@ -852,8 +850,28 @@ template <typename index_at> typename index_at::stats_t compute_stats(index_at c
 template <typename index_at> typename index_at::stats_t compute_level_stats(index_at const &index, std::size_t level) { return index.stats(level); }
 // clang-format on
 
-memory_mapped_file_t memory_map_from_buffer_obj(py::object const& obj) {
-    py::buffer_info info(py::buffer(obj).request());
+template <typename index_at>
+void load_index_from_path(index_at& index, std::string const& path, progress_func_t const& progress) {
+    index.load(path.c_str(), {}, progress_t{progress}).error.raise();
+
+    // Reserve memory and threads for restored index.
+    std::size_t threads = std::thread::hardware_concurrency();
+    if (!index.try_reserve(index_limits_t(index.size(), threads)))
+        throw std::invalid_argument("Out of memory!");
+}
+
+template <typename index_at>
+void view_index_from_path(index_at& index, std::string const& path, progress_func_t const& progress) {
+    index.view(path.c_str(), 0, {}, progress_t{progress}).error.raise();
+
+    // Reserve memory and threads for restored index.
+    std::size_t threads = std::thread::hardware_concurrency();
+    if (!index.try_reserve(index_limits_t(index.size(), threads)))
+        throw std::invalid_argument("Out of memory!");
+}
+
+template <typename py_bytes_at> memory_mapped_file_t memory_map_from_bytes(py_bytes_at&& bytes) {
+    py::buffer_info info(py::buffer(bytes).request());
     return {(byte_t*)(info.ptr), static_cast<std::size_t>(info.size)};
 }
 
@@ -885,11 +903,22 @@ template <typename index_at> py::object save_index_to_buffer(index_at const& ind
 
 template <typename index_at>
 void load_index_from_buffer(index_at& index, py::object const& buffer_obj, progress_func_t const& progress) {
-    index.load(memory_map_from_buffer_obj(buffer_obj), {}, {}, progress_t{progress}).error.raise();
+    index.load(memory_map_from_bytes(buffer_obj), {}, {}, progress_t{progress}).error.raise();
+
+    // Reserve memory and threads for restored index.
+    std::size_t threads = std::thread::hardware_concurrency();
+    if (!index.try_reserve(index_limits_t(index.size(), threads)))
+        throw std::invalid_argument("Out of memory!");
 }
+
 template <typename index_at>
 void view_index_from_buffer(index_at& index, py::object const& buffer_obj, progress_func_t const& progress) {
-    index.view(memory_map_from_buffer_obj(buffer_obj), {}, {}, progress_t{progress}).error.raise();
+    index.view(memory_map_from_bytes(buffer_obj), {}, {}, progress_t{progress}).error.raise();
+
+    // Reserve memory and threads for restored index.
+    std::size_t threads = std::thread::hardware_concurrency();
+    if (!index.try_reserve(index_limits_t(index.size(), threads)))
+        throw std::invalid_argument("Out of memory!");
 }
 
 template <typename index_at> std::vector<typename index_at::stats_t> compute_levels_stats(index_at const& index) {
@@ -1022,7 +1051,7 @@ PYBIND11_MODULE(compiled, m) {
     });
 
     m.def("index_dense_metadata_from_buffer", [](py::object const& buffer_obj) -> py::dict {
-        index_dense_metadata_result_t meta = index_dense_metadata_from_buffer(memory_map_from_buffer_obj(buffer_obj));
+        index_dense_metadata_result_t meta = index_dense_metadata_from_buffer(memory_map_from_bytes(buffer_obj));
         forward_error(meta);
         return index_metadata(meta);
     });

--- a/python/lib.cpp
+++ b/python/lib.cpp
@@ -420,8 +420,8 @@ static py::tuple search_many_in_index( //
     if (wanted == 0)
         return py::tuple(5);
 
-    if (index.limits().threads_search < threads)
-        throw std::invalid_argument("Can't use that many threads!");
+    // Clamp threads to hardware limit instead of throwing
+    threads = std::min<std::size_t>(threads, std::thread::hardware_concurrency());
 
     py::buffer_info vectors_info = vectors.request();
     if (vectors_info.ndim != 2)
@@ -663,8 +663,8 @@ static py::tuple cluster_vectors(        //
     index_at& index, py::buffer queries, //
     std::size_t min_count, std::size_t max_count, std::size_t threads, progress_func_t const& progress) {
 
-    if (index.limits().threads_search < threads)
-        throw std::invalid_argument("Can't use that many threads!");
+    // Clamp threads to hardware limit instead of throwing
+    threads = std::min<std::size_t>(threads, std::thread::hardware_concurrency());
 
     py::buffer_info queries_info = queries.request();
     if (queries_info.ndim != 2)
@@ -737,8 +737,8 @@ static py::tuple cluster_keys(                            //
     index_at& index, py::array_t<dense_key_t> queries_py, //
     std::size_t min_count, std::size_t max_count, std::size_t threads, progress_func_t const& progress) {
 
-    if (index.limits().threads_search < threads)
-        throw std::invalid_argument("Can't use that many threads!");
+    // Clamp threads to hardware limit instead of throwing
+    threads = std::min<std::size_t>(threads, std::thread::hardware_concurrency());
 
     std::size_t queries_count = static_cast<std::size_t>(queries_py.size());
     auto queries_py1d = queries_py.template unchecked<1>();

--- a/python/lib.cpp
+++ b/python/lib.cpp
@@ -1003,11 +1003,11 @@ PYBIND11_MODULE(compiled, m) {
     m.attr("VERSION_MINOR") = py::int_(USEARCH_VERSION_MINOR);
     m.attr("VERSION_PATCH") = py::int_(USEARCH_VERSION_PATCH);
 
-    py::enum_<metric_punned_signature_t>(m, "MetricSignature")
+    py::enum_<metric_punned_signature_t>(m, "MetricSignature", py::arithmetic())
         .value("ArrayArray", metric_punned_signature_t::array_array_k)
         .value("ArrayArraySize", metric_punned_signature_t::array_array_size_k);
 
-    py::enum_<metric_kind_t>(m, "MetricKind")
+    py::enum_<metric_kind_t>(m, "MetricKind", py::arithmetic())
         .value("Unknown", metric_kind_t::unknown_k)
 
         .value("IP", metric_kind_t::ip_k)
@@ -1025,7 +1025,7 @@ PYBIND11_MODULE(compiled, m) {
         .value("Cosine", metric_kind_t::cos_k)
         .value("InnerProduct", metric_kind_t::ip_k);
 
-    py::enum_<scalar_kind_t>(m, "ScalarKind")
+    py::enum_<scalar_kind_t>(m, "ScalarKind", py::arithmetic())
         .value("Unknown", scalar_kind_t::unknown_k)
         .value("B1", scalar_kind_t::b1x8_k)
         .value("U40", scalar_kind_t::u40_k)

--- a/python/scripts/test_index.py
+++ b/python/scripts/test_index.py
@@ -289,7 +289,7 @@ def test_index_save_load_restore_copy(ndim, quantization, batch_size):
 
 @pytest.mark.parametrize("ndim", [3, 8, 32, 256, 4096])
 @pytest.mark.parametrize("batch_size", [1, 7, 1024])
-@pytest.mark.parametrize("threads", [1, 3, 7])
+@pytest.mark.parametrize("threads", [1, 3, 7, 150])
 def test_index_restore_multithread_search(ndim, batch_size, threads):
 
     reset_randomness()
@@ -407,7 +407,7 @@ def test_index_keys_iteration():
     """Test that iterating over index.keys works without infinite loop."""
     index = Index(ndim=3)
     index.add(keys=[42], vectors=np.array([0.2, 0.3, 0.5]))
-    
+
     keys_list = list(index.keys)
     assert len(keys_list) == 1
     assert keys_list[0] == 42

--- a/python/scripts/test_index.py
+++ b/python/scripts/test_index.py
@@ -204,7 +204,7 @@ def test_index_stats(batch_size):
 
 
 @pytest.mark.parametrize("use_view", [True, False])
-def test_index_load_from_buffer(use_view: bool, ndim: int=3, batch_size: int=10):
+def test_index_load_from_buffer(use_view: bool, ndim: int = 3, batch_size: int = 10):
     reset_randomness()
 
     index = Index(ndim=ndim, multi=False)
@@ -285,6 +285,37 @@ def test_index_save_load_restore_copy(ndim, quantization, batch_size):
     deserialized_index.reset()
     index.reset()
     os.remove("tmp.usearch")
+
+
+@pytest.mark.parametrize("ndim", [3, 8, 32, 256, 4096])
+@pytest.mark.parametrize("batch_size", [1, 7, 1024])
+@pytest.mark.parametrize("threads", [1, 3, 7])
+def test_index_restore_multithread_search(ndim, batch_size, threads):
+
+    reset_randomness()
+    quantization = ScalarKind.F32
+    index = Index(ndim=ndim, dtype=quantization, multi=False)
+
+    if batch_size > 0:
+        keys = np.arange(batch_size)
+        vectors = random_vectors(count=batch_size, ndim=ndim, dtype=quantization)
+        index.add(keys, vectors, threads=threads)
+
+    query = random_vectors(count=batch_size, ndim=ndim, dtype=quantization)
+    k = min(batch_size, 10)
+
+    result_original = index.search(query, count=k, threads=threads)
+    dumped_index: bytes = index.save()
+    dumped_index_view = memoryview(dumped_index)
+
+    # When restoring from disk, search must not fail if using multiple threads.
+    index_restored = Index.restore(dumped_index, view=False)
+    result_restored = index_restored.search(query, count=k, threads=threads)
+    assert np.allclose(result_original.distances, result_restored.distances, atol=0.1)
+
+    index_viewed = Index.restore(dumped_index_view, view=True)
+    result_view = index_viewed.search(query, count=k, threads=threads)
+    assert np.allclose(result_original.distances, result_view.distances, atol=0.1)
 
 
 @pytest.mark.parametrize("batch_size", [32])

--- a/python/scripts/test_index.py
+++ b/python/scripts/test_index.py
@@ -403,6 +403,16 @@ def test_index_clustering(ndim, metric, quantization, dtype, batch_size):
     assert len(unique_clusters) >= 3 and len(unique_clusters) <= 10
 
 
+def test_index_keys_iteration():
+    """Test that iterating over index.keys works without infinite loop."""
+    index = Index(ndim=3)
+    index.add(keys=[42], vectors=np.array([0.2, 0.3, 0.5]))
+    
+    keys_list = list(index.keys)
+    assert len(keys_list) == 1
+    assert keys_list[0] == 42
+
+
 def test_index_copied_memory_usage():
     """Test that copy=False results in lower memory usage than copy=True."""
     reset_randomness()

--- a/python/usearch/index.py
+++ b/python/usearch/index.py
@@ -459,8 +459,8 @@ class IndexedKeys(Sequence):
     ) -> Union[Key, np.ndarray]:
         if isinstance(offset_offsets_or_slice, slice):
             start, stop, step = offset_offsets_or_slice.indices(len(self))
-            if step:
-                raise
+            if step != 1:
+                raise ValueError("Slicing with a step is not supported")
             return self.index._compiled.get_keys_in_slice(start, stop - start)
 
         elif isinstance(offset_offsets_or_slice, Iterable):
@@ -469,6 +469,10 @@ class IndexedKeys(Sequence):
 
         else:
             offset = int(offset_offsets_or_slice)
+            if offset < 0:
+                offset += len(self)
+            if offset < 0 or offset >= len(self):
+                raise IndexError("Index out of range")
             return self.index._compiled.get_key_at_offset(offset)
 
     def __array__(self, dtype=None) -> np.ndarray:


### PR DESCRIPTION
Thanks to @Stefano-t the Python and JS bindings require one less step to start working with a restored index. It was a common usability issue, and now it's gone!