### PR TITLE
Add: Rust function to the usearch crate version

### DIFF
--- a/rust/lib.rs
+++ b/rust/lib.rs
@@ -17,6 +17,11 @@
 //!
 //! Refer to the `Index` struct for detailed usage examples.
 
+/// Returns the version of the USearch crate.
+pub fn version() -> &'static str {
+    env!("CARGO_PKG_VERSION")
+}
+
 /// The key type used to identify vectors in the index.
 /// It is a 64-bit unsigned integer.
 pub type Key = u64;


### PR DESCRIPTION
It would be beneficial to add a usearch::version() function that returns the crate's version string at runtime.

This functionality is useful for applications that need to log/provide dependency versions. For example, it would be helpful in the https://github.com/scylladb/vector-store/pull/213.