### PR TITLE
Broader GoLang API

### DIFF
--- a/golang/lib_test.go
+++ b/golang/lib_test.go
@@ -4,6 +4,7 @@ import (
 	"math"
 	"runtime"
 	"testing"
+	"unsafe"
 )
 
 func TestUSearch(t *testing.T) {
@@ -102,6 +103,43 @@ func TestUSearch(t *testing.T) {
 		}
 	})
 
+	t.Run("Test Insertion with pointer", func(t *testing.T) {
+		dim := uint(128)
+		conf := DefaultConfig(dim)
+		ind, err := NewIndex(conf)
+		if err != nil {
+			t.Fatalf("Failed to construct the index: %s", err)
+		}
+		defer ind.Destroy()
+
+		err = ind.Reserve(100)
+		if err != nil {
+			t.Fatalf("Failed to reserve capacity: %s", err)
+		}
+
+		err = ind.ChangeThreadsAdd(10)
+		if err != nil {
+			t.Fatalf("Failed to change threads add: %s", err)
+		}
+
+		vec := make([]float32, dim)
+		vec[0] = 40.0
+		vec[1] = 2.0
+
+		err = ind.AddWithPointer(42, unsafe.Pointer(&vec[0]))
+		if err != nil {
+			t.Fatalf("Failed to insert: %s", err)
+		}
+
+		found_len, err := ind.Len()
+		if err != nil {
+			t.Fatalf("Failed to retrieve size after insertion: %s", err)
+		}
+		if found_len != 1 {
+			t.Fatalf("Expected size to be 1, got %d", found_len)
+		}
+	})
+
 	t.Run("Test Search", func(t *testing.T) {
 		dim := uint(128)
 		conf := DefaultConfig(dim)
@@ -131,6 +169,48 @@ func TestUSearch(t *testing.T) {
 		}
 
 		keys, distances, err := ind.Search(vec, 10)
+		if err != nil {
+			t.Fatalf("Failed to search: %s", err)
+		}
+
+		const tolerance = 1e-2 // For example, this sets the tolerance to 0.01
+		if keys[0] != 42 || math.Abs(float64(distances[0])) > tolerance {
+			t.Fatalf("Expected result 42 with distance 0, got key %d with distance %f", keys[0], distances[0])
+		}
+
+		// TODO: Add exact search
+	})
+
+	t.Run("Test Search With Pointer", func(t *testing.T) {
+		dim := uint(128)
+		conf := DefaultConfig(dim)
+		ind, err := NewIndex(conf)
+		if err != nil {
+			t.Fatalf("Failed to construct the index: %s", err)
+		}
+		defer ind.Destroy()
+
+		err = ind.Reserve(100)
+		if err != nil {
+			t.Fatalf("Failed to reserve capacity: %s", err)
+		}
+
+		err = ind.ChangeThreadsSearch(10)
+		if err != nil {
+			t.Fatalf("Failed to change threads search: %s", err)
+		}
+
+		vec := make([]float32, dim)
+		vec[0] = 40.0
+		vec[1] = 2.0
+
+		ptr := unsafe.Pointer(&vec[0])
+		err = ind.AddWithPointer(42, ptr)
+		if err != nil {
+			t.Fatalf("Failed to insert: %s", err)
+		}
+
+		keys, distances, err := ind.SearchWithPointer(ptr, 10)
 		if err != nil {
 			t.Fatalf("Failed to search: %s", err)
 		}
@@ -225,5 +305,280 @@ func TestUSearch(t *testing.T) {
 		}
 
 		// TODO: Check file save/load/metadata
+	})
+
+	t.Run("Test Save and Load With Pointer", func(t *testing.T) {
+		dim := uint(128)
+		conf := DefaultConfig(dim)
+		ind, err := NewIndex(conf)
+		if err != nil {
+			t.Fatalf("Failed to construct the index: %s", err)
+		}
+		defer ind.Destroy()
+		ind2, err := NewIndex(conf)
+		if err != nil {
+			t.Fatalf("Failed to construct the index: %s", err)
+		}
+		defer ind2.Destroy()
+		indView, err := NewIndex(conf)
+		if err != nil {
+			t.Fatalf("Failed to construct the index: %s", err)
+		}
+		defer indView.Destroy()
+
+		err = ind.Reserve(100)
+		if err != nil {
+			t.Fatalf("Failed to reserve capacity: %s", err)
+		}
+
+		vec := make([]float32, dim)
+		for i := uint(0); i < dim; i++ {
+			vec[i] = float32(i) + 0.2
+			err = ind.AddWithPointer(uint64(i), unsafe.Pointer(&vec[0]))
+			if err != nil {
+				t.Fatalf("Failed to insert: %s", err)
+			}
+		}
+
+		ind_length, err := ind.Len()
+		if err != nil {
+			t.Fatalf("Failed to retrieve size: %s", err)
+		}
+
+		// TODO: Add invalid save and loads?
+		buffer_size := uint(1 * 1024 * 1024)
+		buf := make([]byte, buffer_size)
+		err = ind.SaveBuffer(buf, buffer_size)
+		if err != nil {
+			t.Fatalf("Failed to save the index to a buffer: %s", err)
+		}
+
+		err = ind2.LoadBuffer(buf, buffer_size)
+		if err != nil {
+			t.Fatalf("Failed to load the index from a buffer: %s", err)
+		}
+
+		ind2_length, err := ind2.Len()
+		if err != nil {
+			t.Fatalf("Failed to retrieve size: %s", err)
+		}
+		if ind_length != ind2_length {
+			t.Fatalf("Loaded index length %d doesn't match original of %d ", ind2_length, ind_length)
+		}
+		// TODO: Check some values
+
+		err = indView.ViewBuffer(buf, buffer_size)
+		if err != nil {
+			t.Fatalf("Failed to load the view from a buffer: %s", err)
+		}
+
+		indView_length, err := indView.Len()
+		if err != nil {
+			t.Fatalf("Failed to retrieve size: %s", err)
+		}
+		if ind_length != indView_length {
+			t.Fatalf("Loaded view length %d doesn't match original of %d ", indView_length, ind_length)
+		}
+
+		conf, err = MetadataBuffer(buf, buffer_size)
+		if err != nil {
+			t.Fatalf("Failed to load the metadata from a buffer: %s", err)
+		}
+		if conf != ind.config {
+			t.Fatalf("Loaded metadata doesn't match the index metadata")
+		}
+
+		// TODO: Check file save/load/metadata
+	})
+}
+
+func TestUSearchDataType(t *testing.T) {
+
+	t.Run("Test Save and Load With F64", func(t *testing.T) {
+		dim := uint(128)
+		conf := DefaultConfig(dim)
+		conf.Quantization = F64
+		ind, err := NewIndex(conf)
+		if err != nil {
+			t.Fatalf("Failed to construct the index: %s", err)
+		}
+		defer ind.Destroy()
+		ind2, err := NewIndex(conf)
+		if err != nil {
+			t.Fatalf("Failed to construct the index: %s", err)
+		}
+		defer ind2.Destroy()
+		indView, err := NewIndex(conf)
+		if err != nil {
+			t.Fatalf("Failed to construct the index: %s", err)
+		}
+		defer indView.Destroy()
+
+		err = ind.Reserve(100)
+		if err != nil {
+			t.Fatalf("Failed to reserve capacity: %s", err)
+		}
+
+		vec := make([]float64, dim)
+		for i := uint(0); i < dim; i++ {
+			vec[i] = float64(i) + 0.2
+			err = ind.AddWithPointer(uint64(i), unsafe.Pointer(&vec[0]))
+			if err != nil {
+				t.Fatalf("Failed to insert: %s", err)
+			}
+		}
+
+		ind_length, err := ind.Len()
+		if err != nil {
+			t.Fatalf("Failed to retrieve size: %s", err)
+		}
+
+		// TODO: Add invalid save and loads?
+		buffer_size := uint(1 * 1024 * 1024)
+		buf := make([]byte, buffer_size)
+		err = ind.SaveBuffer(buf, buffer_size)
+		if err != nil {
+			t.Fatalf("Failed to save the index to a buffer: %s", err)
+		}
+
+		err = ind2.LoadBuffer(buf, buffer_size)
+		if err != nil {
+			t.Fatalf("Failed to load the index from a buffer: %s", err)
+		}
+
+		ind2_length, err := ind2.Len()
+		if err != nil {
+			t.Fatalf("Failed to retrieve size: %s", err)
+		}
+		if ind_length != ind2_length {
+			t.Fatalf("Loaded index length %d doesn't match original of %d ", ind2_length, ind_length)
+		}
+		// TODO: Check some values
+
+		err = indView.ViewBuffer(buf, buffer_size)
+		if err != nil {
+			t.Fatalf("Failed to load the view from a buffer: %s", err)
+		}
+
+		indView_length, err := indView.Len()
+		if err != nil {
+			t.Fatalf("Failed to retrieve size: %s", err)
+		}
+		if ind_length != indView_length {
+			t.Fatalf("Loaded view length %d doesn't match original of %d ", indView_length, ind_length)
+		}
+
+		conf, err = MetadataBuffer(buf, buffer_size)
+		if err != nil {
+			t.Fatalf("Failed to load the metadata from a buffer: %s", err)
+		}
+		if conf != ind.config {
+			t.Fatalf("Loaded metadata doesn't match the index metadata")
+		}
+
+		// TODO: Check file save/load/metadata
+		keys, distances, err := ind.SearchWithPointer(unsafe.Pointer(&vec[0]), dim)
+		if err != nil {
+			t.Fatalf("Failed to search: %s", err)
+		}
+
+		const tolerance = 1e-2 // For example, this sets the tolerance to 0.01
+		if keys[0] != 127 || math.Abs(float64(distances[0])) > tolerance {
+			t.Fatalf("Expected result 42 with distance 0, got key %d with distance %f", keys[0], distances[0])
+		}
+	})
+
+	t.Run("Test Save and Load With F64", func(t *testing.T) {
+		dim := uint(128)
+		conf := DefaultConfig(dim)
+		conf.Quantization = F64
+		ind, err := NewIndex(conf)
+		if err != nil {
+			t.Fatalf("Failed to construct the index: %s", err)
+		}
+		defer ind.Destroy()
+		ind2, err := NewIndex(conf)
+		if err != nil {
+			t.Fatalf("Failed to construct the index: %s", err)
+		}
+		defer ind2.Destroy()
+		indView, err := NewIndex(conf)
+		if err != nil {
+			t.Fatalf("Failed to construct the index: %s", err)
+		}
+		defer indView.Destroy()
+
+		err = ind.Reserve(100)
+		if err != nil {
+			t.Fatalf("Failed to reserve capacity: %s", err)
+		}
+
+		vec := make([]float64, dim)
+		for i := uint(0); i < dim; i++ {
+			vec[i] = float64(i) + 0.2
+			err = ind.AddWithPointer(uint64(i), unsafe.Pointer(&vec[0]))
+			if err != nil {
+				t.Fatalf("Failed to insert: %s", err)
+			}
+		}
+
+		ind_length, err := ind.Len()
+		if err != nil {
+			t.Fatalf("Failed to retrieve size: %s", err)
+		}
+
+		// TODO: Add invalid save and loads?
+		buffer_size := uint(1 * 1024 * 1024)
+		buf := make([]byte, buffer_size)
+		err = ind.SaveBuffer(buf, buffer_size)
+		if err != nil {
+			t.Fatalf("Failed to save the index to a buffer: %s", err)
+		}
+
+		err = ind2.LoadBuffer(buf, buffer_size)
+		if err != nil {
+			t.Fatalf("Failed to load the index from a buffer: %s", err)
+		}
+
+		ind2_length, err := ind2.Len()
+		if err != nil {
+			t.Fatalf("Failed to retrieve size: %s", err)
+		}
+		if ind_length != ind2_length {
+			t.Fatalf("Loaded index length %d doesn't match original of %d ", ind2_length, ind_length)
+		}
+		// TODO: Check some values
+
+		err = indView.ViewBuffer(buf, buffer_size)
+		if err != nil {
+			t.Fatalf("Failed to load the view from a buffer: %s", err)
+		}
+
+		indView_length, err := indView.Len()
+		if err != nil {
+			t.Fatalf("Failed to retrieve size: %s", err)
+		}
+		if ind_length != indView_length {
+			t.Fatalf("Loaded view length %d doesn't match original of %d ", indView_length, ind_length)
+		}
+
+		conf, err = MetadataBuffer(buf, buffer_size)
+		if err != nil {
+			t.Fatalf("Failed to load the metadata from a buffer: %s", err)
+		}
+		if conf != ind.config {
+			t.Fatalf("Loaded metadata doesn't match the index metadata")
+		}
+
+		// TODO: Check file save/load/metadata
+		keys, distances, err := ind.SearchWithPointer(unsafe.Pointer(&vec[0]), dim)
+		if err != nil {
+			t.Fatalf("Failed to search: %s", err)
+		}
+
+		const tolerance = 1e-2 // For example, this sets the tolerance to 0.01
+		if keys[0] != 127 || math.Abs(float64(distances[0])) > tolerance {
+			t.Fatalf("Expected result 42 with distance 0, got key %d with distance %f", keys[0], distances[0])
+		}
 	})
 }

--- a/golang/lib_test.go
+++ b/golang/lib_test.go
@@ -394,10 +394,9 @@ func TestUSearch(t *testing.T) {
 
 func TestUSearchDataType(t *testing.T) {
 
-	t.Run("Test Save and Load With F64", func(t *testing.T) {
+	t.Run("Test Save and Load With F32", func(t *testing.T) {
 		dim := uint(128)
 		conf := DefaultConfig(dim)
-		conf.Quantization = F64
 		ind, err := NewIndex(conf)
 		if err != nil {
 			t.Fatalf("Failed to construct the index: %s", err)
@@ -419,9 +418,9 @@ func TestUSearchDataType(t *testing.T) {
 			t.Fatalf("Failed to reserve capacity: %s", err)
 		}
 
-		vec := make([]float64, dim)
+		vec := make([]float32, dim)
 		for i := uint(0); i < dim; i++ {
-			vec[i] = float64(i) + 0.2
+			vec[i] = float32(i) + 0.2
 			err = ind.AddWithPointer(uint64(i), unsafe.Pointer(&vec[0]))
 			if err != nil {
 				t.Fatalf("Failed to insert: %s", err)


### PR DESCRIPTION
Currently, golang API only support float32 as input type.  This PR add new interfaces such as AddWithPointer, SearchWithPointer with unsafe.Pointer instead of []float32 in order to support all types. 