### PR TITLE
Add a parameter to index_dense_gt::make() function

### DIFF
--- a/include/usearch/index_dense.hpp
+++ b/include/usearch/index_dense.hpp
@@ -641,9 +641,10 @@ class index_dense_gt {
      *  ! the `change_metric` method before the index can be used. Alternatively,
      *  ! if you are loading an existing index, the metric will be set automatically.
      */
-    static state_result_t make(           //
-        metric_t metric = {},             //
-        index_dense_config_t config = {}, //
+    static state_result_t make(             //
+        metric_t metric = {},               //
+        index_dense_config_t config = {},   //
+        bool create_internal_index = true,  //
         vector_key_t free_key = default_free_value<vector_key_t>()) {
 
         if (metric.missing())
@@ -667,8 +668,10 @@ class index_dense_gt {
             index.metric_ = metric;
         }
 
-        new (raw) index_t(config);
-        index.typed_ = raw;
+        if (create_internal_index) {
+            new (raw) index_t(config);
+            index.typed_ = raw;
+        }
         return result;
     }
 


### PR DESCRIPTION
Fixes #656

## Usage

```c++
using namespace unum::usearch;

auto cfg = index_dense_config_t{};
cfg.enable_key_lookups = false;
auto idx = index_dense_gt<uint64_t, uint32_t>::make({}, cfg, false); // <- here!
auto res = idx.view({buffer, buffer_size});

idx.change_metric(metric_punned_t{dimension,
                                  metric_kind_t::cos_k,
                                  scalar_kind_t::f32_k});
idx.change_expansion_search(ef_search);

auto search_res = idx.search(query, wanted_cnt);
```