### PR TITLE
Breaking revamp of Rust bindings for v3

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/rust/lib.rs
+++ b/rust/lib.rs
@@ -642,7 +642,7 @@ impl std::fmt::Debug for IndexOperationError {
 /// The `VectorType` trait defines operations for managing and querying vectors
 /// in an index. It supports generic operations on vectors of different types,
 /// allowing for the addition, retrieval, and search of vectors within an index.
-pub trait VectorType {
+pub unsafe trait VectorType: Sized {
     const KIND: ScalarKind;
 
     /// Adds a vector to the index under the specified key.
@@ -655,10 +655,7 @@ pub trait VectorType {
     /// # Returns
     /// - `Ok(())` if the vector was successfully added to the index.
     /// - `Err(IndexOperationError)` if an error occurred during the operation.
-    fn add(index: &Index, key: Key, vector: &[Self]) -> Result<(), IndexOperationError>
-    where
-        Self: Sized,
-    {
+    fn add(index: &Index, key: Key, vector: &[Self]) -> Result<(), IndexOperationError> {
         if !is_kind_convertible_to(index.scalar_kind, Self::KIND) {
             return Err(IndexOperationError::TypeError(
                 Self::KIND,
@@ -695,10 +692,7 @@ pub trait VectorType {
     /// # Retuns
     /// - `Ok(usize)` indicating the number of elements actually written into the `buffer`.
     /// - `Err(IndexOperationError)` if an error occurred during the operation.
-    fn get(index: &Index, key: Key, buffer: &mut [Self]) -> Result<usize, IndexOperationError>
-    where
-        Self: Sized,
-    {
+    fn get(index: &Index, key: Key, buffer: &mut [Self]) -> Result<usize, IndexOperationError> {
         if !is_kind_convertible_to(index.scalar_kind, Self::KIND) {
             return Err(IndexOperationError::TypeError(
                 Self::KIND,
@@ -724,9 +718,7 @@ pub trait VectorType {
         index: &Index,
         key: Key,
         buffer: &mut [Self],
-    ) -> Result<usize, cxx::Exception>
-    where
-        Self: Sized;
+    ) -> Result<usize, cxx::Exception>;
 
     /// Performs a search in the index using the given query vector, returning
     /// up to `count` closest matches.
@@ -743,10 +735,7 @@ pub trait VectorType {
         index: &Index,
         query: &[Self],
         count: usize,
-    ) -> Result<ffi::Matches, IndexOperationError>
-    where
-        Self: Sized,
-    {
+    ) -> Result<ffi::Matches, IndexOperationError> {
         if !is_kind_convertible_to(index.scalar_kind, Self::KIND) {
             return Err(IndexOperationError::TypeError(
                 Self::KIND,
@@ -772,9 +761,7 @@ pub trait VectorType {
         index: &Index,
         query: &[Self],
         count: usize,
-    ) -> Result<ffi::Matches, cxx::Exception>
-    where
-        Self: Sized;
+    ) -> Result<ffi::Matches, cxx::Exception>;
 
     /// Performs an exact (brute force) search in the index using the given query vector, returning
     /// up to `count` closest matches. This search checks all vectors in the index, guaranteeing to find
@@ -792,10 +779,7 @@ pub trait VectorType {
         index: &Index,
         query: &[Self],
         count: usize,
-    ) -> Result<ffi::Matches, IndexOperationError>
-    where
-        Self: Sized,
-    {
+    ) -> Result<ffi::Matches, IndexOperationError> {
         if !is_kind_convertible_to(index.scalar_kind, Self::KIND) {
             return Err(IndexOperationError::TypeError(
                 Self::KIND,
@@ -821,9 +805,7 @@ pub trait VectorType {
         index: &Index,
         query: &[Self],
         count: usize,
-    ) -> Result<ffi::Matches, cxx::Exception>
-    where
-        Self: Sized;
+    ) -> Result<ffi::Matches, cxx::Exception>;
 
     /// Performs a filtered search in the index using a query vector and a custom
     /// filter function, returning up to `count` matches that satisfy the filter.
@@ -845,7 +827,6 @@ pub trait VectorType {
         filter: F,
     ) -> Result<ffi::Matches, IndexOperationError>
     where
-        Self: Sized,
         F: Fn(Key) -> bool,
     {
         if !is_kind_convertible_to(index.scalar_kind, Self::KIND) {
@@ -877,7 +858,6 @@ pub trait VectorType {
         filter: F,
     ) -> Result<ffi::Matches, cxx::Exception>
     where
-        Self: Sized,
         F: Fn(Key) -> bool;
 
     /// Changes the metric used for distance calculations within the index.
@@ -893,10 +873,7 @@ pub trait VectorType {
     fn change_metric(
         index: &mut Index,
         metric: std::boxed::Box<dyn Fn(*const Self, *const Self) -> Distance + Send + Sync>,
-    ) -> Result<(), IndexOperationError>
-    where
-        Self: Sized,
-    {
+    ) -> Result<(), IndexOperationError> {
         // TODO: same question as higher up. what kind of casts are allowed and sensible here?
         if !is_kind_convertible_to(index.scalar_kind, Self::KIND) {
             return Err(IndexOperationError::TypeError(
@@ -922,11 +899,9 @@ pub trait VectorType {
         index: &mut Index,
         metric: std::boxed::Box<dyn Fn(*const Self, *const Self) -> Distance + Send + Sync>,
     ) -> Result<(), cxx::Exception>
-    where
-        Self: Sized;
 }
 
-impl VectorType for f32 {
+unsafe impl VectorType for f32 {
     const KIND: ScalarKind = ScalarKind::F32;
 
     unsafe fn search_unchecked(
@@ -1015,7 +990,7 @@ impl VectorType for f32 {
     }
 }
 
-impl VectorType for i8 {
+unsafe impl VectorType for i8 {
     const KIND: ScalarKind = ScalarKind::I8;
 
     unsafe fn search_unchecked(
@@ -1103,7 +1078,7 @@ impl VectorType for i8 {
     }
 }
 
-impl VectorType for f64 {
+unsafe impl VectorType for f64 {
     const KIND: ScalarKind = ScalarKind::F64;
 
     unsafe fn search_unchecked(
@@ -1191,7 +1166,7 @@ impl VectorType for f64 {
     }
 }
 
-impl VectorType for f16 {
+unsafe impl VectorType for f16 {
     const KIND: ScalarKind = ScalarKind::F16;
 
     unsafe fn search_unchecked(
@@ -1280,7 +1255,7 @@ impl VectorType for f16 {
     }
 }
 
-impl VectorType for b1x8 {
+unsafe impl VectorType for b1x8 {
     const KIND: ScalarKind = ScalarKind::B1;
 
     unsafe fn search_unchecked(

--- a/rust/lib.rs
+++ b/rust/lib.rs
@@ -481,6 +481,7 @@ pub use ffi::{IndexOptions, MetricKind, ScalarKind};
 /// ```
 ///
 /// In this example, `dimensions` should be defined and valid for the vectors `a` and `b`.
+#[doc(hidden)]
 pub enum MetricFunctionPtr {
     B1X8Metric(*mut std::boxed::Box<dyn Fn(*const b1x8, *const b1x8) -> Distance + Send + Sync>),
     I8Metric(*mut std::boxed::Box<dyn Fn(*const i8, *const i8) -> Distance + Send + Sync>),


### PR DESCRIPTION
Related to #574 , draft for the v3 Rust bindings. If we're gonna break APIs, let's just go all the way :D

The goal is to prevent unsoundness from the safe Rust interface, turning as many illegal operations as possible into compile errors , and catch the others at runtime.

Sorry for the mega-PR, but I don't know if it makes sense to split this up since all changes kind of affect everything.

## Error handling, type safety

In general: existing methods on `VectorType` become `unsafe fn xxx_unchecked`, and safe variants are added that check all required invariants.

There's some ambiguity as to what is actually invalid/unsafe here. As far as I can tell, using an Index created with one `ScalarKind` (say `int8`) as one of a different type (like inserting an `f64` vector) does not actually cause any memory unsafety. It can garble data though, which I'd say is enough to make the operation `unsafe` (pretty common in the ecosystem AFAIK?).

So I've added a check that the casts that will be done on the C++ make sense, but it would be good to have more opinions on which ones are ok and which ones are almost certainly mistakes. Some are easy (`f32` to `f16`, `bf16` is ok, `f64` to `b1x8` is not for example), others less so.

## Safe `Index` views into file, buffer

Currently you can have an `Index` reading a buffer passed in by the user, which will hopefully stay live as long as the `Index`. Though the method is marked unsafe, it's easy to create a dangling pointer situation which is unfortunate in Rust of all places. Also, these immutable `Index` views will throw exceptions if any mutating methods are called on them.

My proposed solution is to separate the regular, mutable `Index` that owns its memory and the immutable `IndexView` into different types. This way `IndexView` can be associated with a lifetime so the backing buffer can't be dropped while it's being used, and the `IndexView` object (holding a pointer) can not be moved between threads.

While we're at it, splitting mutating and readonly methods on `Index` into different traits allows `IndexView` to only expose read methods and prevent some runtime exceptions this way.

## Custom metric closure shenanigans

This part could maybe be split into a different PR. First a lot of duplicated code can be written in a generic way, which is always nice. There's also a memory leak pointed out in #629 (fixed by properly dropping the currently set metric closure when it's overwritten).

I only noticed that because I wanted to see how ergonomics could be improved here. Currently custom metrics are boxed closures taking `*const T` arguments, which would be very nice to instead turn into `&[T]` slices of correct length/dimensionality. Also, closures are currently double-boxed because `Box<dyn Fn..>` is a wide pointer, and `metric_punned_t` wants a regular pointer, so there's three (if I'm counting correctly) pointer dereferences per call to the metric function (trampoline -> pointer to wide pointer -> dynamic dispatch for `dyn Fn` trait object). 

I *think* it's possible to add a shim in there to turn the pointers into slices without adding another indirection (currently `closure_address` is a pointer to the `Box<dyn>`, when it could instead point to the trait object/wide pointer instead and the trampoline casts that into a valid trait object reference). But I'm not sure if it's worth it when you could also just allow the user a regular `fn (&[T], &[T]) -> Distance` pointer, which avoid a lot of that and covers many (most?) use cases just fine.

FFI and closures is a difficult topic though so it would be cool for other to weigh in and check what I'm saying is correct.