### PR TITLE
Fix: Avoid duplicate neighbor slots in HNSW reverse links

### DIFF
--- a/include/usearch/index.hpp
+++ b/include/usearch/index.hpp
@@ -3899,7 +3899,8 @@ class index_gt {
             // If `new_slot` is already present in the neighboring connections of `close_slot`
             // then no need to modify any connections or run the heuristics.
             if (close_header.size() < connectivity_max) {
-                if (std::find(close_header.begin(), close_header.end(), new_slot) == close_header.end()) {
+                if (std::find_if(close_header.begin(), close_header.end(),
+                                 [new_slot](compressed_slot_t slot) { return slot == new_slot; }) == close_header.end()) {
                     close_header.push_back(new_slot);
                 }
                 continue;


### PR DESCRIPTION
This PR fixes https://github.com/unum-cloud/USearch/issues/698.