### PR TITLE
Fix: Match Rust move semantics

### DIFF
--- a/rust/lib.cpp
+++ b/rust/lib.cpp
@@ -211,8 +211,10 @@ std::unique_ptr<NativeIndex> new_native_index(IndexOptions const& options) {
     index_dense_config_t config(options.connectivity, options.expansion_add, options.expansion_search);
     config.multi = options.multi;
     index_t index = index_t::make(metric, config);
-    // In Rust we have the luxury of returning a `Result` type even for the constructor.
-    // So let's pre-reserve the maximal number of threads and return the error if it fails.
-    index.reserve(index_limits_t{});
-    return wrap(std::move(index));
+
+    // Preserve constructor pre-allocation semantics (`index_limits_t{}`), but execute
+    // reserve after heap allocation to avoid move-induced pointer invalidation.
+    std::unique_ptr<NativeIndex> native = wrap(std::move(index));
+    native->reserve_capacity_and_threads(0, std::thread::hardware_concurrency());
+    return native;
 }

--- a/rust/lib.rs
+++ b/rust/lib.rs
@@ -1518,6 +1518,43 @@ mod tests {
     }
 
     #[test]
+    fn test_new_index_does_not_preallocate_members() {
+        let options = IndexOptions {
+            dimensions: 8,
+            quantization: ScalarKind::F32,
+            ..Default::default()
+        };
+        let index = Index::new(&options).unwrap();
+
+        // Regression check: constructor should preserve `index_limits_t{}` behavior
+        // and avoid reserving member slots up front.
+        assert_eq!(index.capacity(), 0);
+    }
+
+    #[test]
+    fn test_index_survives_box_and_arc_moves_after_construction() {
+        let options = IndexOptions {
+            dimensions: 4,
+            quantization: ScalarKind::F32,
+            ..Default::default()
+        };
+        let vector = [0.25f32, 0.5, 0.75, 1.0];
+
+        let boxed = Box::new(Index::new(&options).unwrap());
+        boxed.reserve(8).unwrap();
+        boxed.add(7, &vector).unwrap();
+        let boxed_matches = boxed.search(&vector, 1).unwrap();
+        assert_eq!(boxed_matches.keys.first().copied(), Some(7));
+
+        let arc = std::sync::Arc::new(Index::new(&options).unwrap());
+        let moved_arc = std::sync::Arc::clone(&arc);
+        moved_arc.reserve_capacity_and_threads(8, 2).unwrap();
+        moved_arc.add(9, &vector).unwrap();
+        let arc_matches = arc.search(&vector, 1).unwrap();
+        assert_eq!(arc_matches.keys.first().copied(), Some(9));
+    }
+
+    #[test]
     fn test_add_get_vector() {
         let options = IndexOptions {
             dimensions: 5,


### PR DESCRIPTION
fix(rust): call reserve() after heap allocation to prevent segfaults

Calling reserve() on stack-allocated index before moving to heap stores dangling pointers, causing crashes when Index is used in Rust structs, Box, Arc, or any moved context.

Move reserve() call to wrap() function after heap allocation.

Just as a reference this came up with trying to implement usearch in https://github.com/madmax983/GallifreyDB to replace hnsw_rs.



