### PR TITLE
Add: `radius` parameter for distance-bounded search

### DIFF
--- a/include/usearch/index.hpp
+++ b/include/usearch/index.hpp
@@ -1437,6 +1437,10 @@ struct index_search_config_t {
 
     /// @brief Brute-forces exhaustive search over all entries in the index.
     bool exact = false;
+
+    /// @brief Maximum search radius. Results with distance greater than this are excluded.
+    /// Defaults to infinity, meaning no filtering is applied.
+    float radius = std::numeric_limits<float>::infinity();
 };
 
 struct index_cluster_config_t {
@@ -3072,6 +3076,18 @@ class index_gt {
 
         top.sort_ascending();
         top.shrink(wanted);
+
+        if (std::isfinite(config.radius)) {
+            candidate_t const* data = top.data();
+            std::size_t within_radius = top.size();
+            for (std::size_t i = 0; i < top.size(); ++i) {
+                if (data[i].distance > static_cast<distance_t>(config.radius)) {
+                    within_radius = i;
+                    break;
+                }
+            }
+            top.shrink(within_radius);
+        }
 
         // Normalize stats
         result.computed_distances = context.computed_distances - result.computed_distances;

--- a/include/usearch/index_dense.hpp
+++ b/include/usearch/index_dense.hpp
@@ -764,19 +764,19 @@ class index_dense_gt {
     add_result_t add(vector_key_t key, f32_t const* vector, std::size_t thread = any_thread(), bool copy_vector = true) { return add_(key, vector, thread, copy_vector, casts_.from.f32); }
     add_result_t add(vector_key_t key, f64_t const* vector, std::size_t thread = any_thread(), bool copy_vector = true) { return add_(key, vector, thread, copy_vector, casts_.from.f64); }
 
-    search_result_t search(b1x8_t const* vector, std::size_t wanted, std::size_t thread = any_thread(), bool exact = false) const { return search_(vector, wanted, dummy_predicate_t {}, thread, exact, casts_.from.b1x8); }
-    search_result_t search(i8_t const* vector, std::size_t wanted, std::size_t thread = any_thread(), bool exact = false) const { return search_(vector, wanted, dummy_predicate_t {}, thread, exact, casts_.from.i8); }
-    search_result_t search(f16_t const* vector, std::size_t wanted, std::size_t thread = any_thread(), bool exact = false) const { return search_(vector, wanted, dummy_predicate_t {}, thread, exact, casts_.from.f16); }
-    search_result_t search(bf16_t const* vector, std::size_t wanted, std::size_t thread = any_thread(), bool exact = false) const { return search_(vector, wanted, dummy_predicate_t {}, thread, exact, casts_.from.bf16); }
-    search_result_t search(f32_t const* vector, std::size_t wanted, std::size_t thread = any_thread(), bool exact = false) const { return search_(vector, wanted, dummy_predicate_t {}, thread, exact, casts_.from.f32); }
-    search_result_t search(f64_t const* vector, std::size_t wanted, std::size_t thread = any_thread(), bool exact = false) const { return search_(vector, wanted, dummy_predicate_t {}, thread, exact, casts_.from.f64); }
+    search_result_t search(b1x8_t const* vector, std::size_t wanted, std::size_t thread = any_thread(), bool exact = false, float radius = std::numeric_limits<float>::infinity()) const { return search_(vector, wanted, dummy_predicate_t {}, thread, exact, radius, casts_.from.b1x8); }
+    search_result_t search(i8_t const* vector, std::size_t wanted, std::size_t thread = any_thread(), bool exact = false, float radius = std::numeric_limits<float>::infinity()) const { return search_(vector, wanted, dummy_predicate_t {}, thread, exact, radius, casts_.from.i8); }
+    search_result_t search(f16_t const* vector, std::size_t wanted, std::size_t thread = any_thread(), bool exact = false, float radius = std::numeric_limits<float>::infinity()) const { return search_(vector, wanted, dummy_predicate_t {}, thread, exact, radius, casts_.from.f16); }
+    search_result_t search(bf16_t const* vector, std::size_t wanted, std::size_t thread = any_thread(), bool exact = false, float radius = std::numeric_limits<float>::infinity()) const { return search_(vector, wanted, dummy_predicate_t {}, thread, exact, radius, casts_.from.bf16); }
+    search_result_t search(f32_t const* vector, std::size_t wanted, std::size_t thread = any_thread(), bool exact = false, float radius = std::numeric_limits<float>::infinity()) const { return search_(vector, wanted, dummy_predicate_t {}, thread, exact, radius, casts_.from.f32); }
+    search_result_t search(f64_t const* vector, std::size_t wanted, std::size_t thread = any_thread(), bool exact = false, float radius = std::numeric_limits<float>::infinity()) const { return search_(vector, wanted, dummy_predicate_t {}, thread, exact, radius, casts_.from.f64); }
 
-    template <typename predicate_at> search_result_t filtered_search(b1x8_t const* vector, std::size_t wanted, predicate_at&& predicate, std::size_t thread = any_thread(), bool exact = false) const { return search_(vector, wanted, std::forward<predicate_at>(predicate), thread, exact, casts_.from.b1x8); }
-    template <typename predicate_at> search_result_t filtered_search(i8_t const* vector, std::size_t wanted, predicate_at&& predicate, std::size_t thread = any_thread(), bool exact = false) const { return search_(vector, wanted, std::forward<predicate_at>(predicate), thread, exact, casts_.from.i8); }
-    template <typename predicate_at> search_result_t filtered_search(f16_t const* vector, std::size_t wanted, predicate_at&& predicate, std::size_t thread = any_thread(), bool exact = false) const { return search_(vector, wanted, std::forward<predicate_at>(predicate), thread, exact, casts_.from.f16); }
-    template <typename predicate_at> search_result_t filtered_search(bf16_t const* vector, std::size_t wanted, predicate_at&& predicate, std::size_t thread = any_thread(), bool exact = false) const { return search_(vector, wanted, std::forward<predicate_at>(predicate), thread, exact, casts_.from.bf16); }
-    template <typename predicate_at> search_result_t filtered_search(f32_t const* vector, std::size_t wanted, predicate_at&& predicate, std::size_t thread = any_thread(), bool exact = false) const { return search_(vector, wanted, std::forward<predicate_at>(predicate), thread, exact, casts_.from.f32); }
-    template <typename predicate_at> search_result_t filtered_search(f64_t const* vector, std::size_t wanted, predicate_at&& predicate, std::size_t thread = any_thread(), bool exact = false) const { return search_(vector, wanted, std::forward<predicate_at>(predicate), thread, exact, casts_.from.f64); }
+    template <typename predicate_at> search_result_t filtered_search(b1x8_t const* vector, std::size_t wanted, predicate_at&& predicate, std::size_t thread = any_thread(), bool exact = false, float radius = std::numeric_limits<float>::infinity()) const { return search_(vector, wanted, std::forward<predicate_at>(predicate), thread, exact, radius, casts_.from.b1x8); }
+    template <typename predicate_at> search_result_t filtered_search(i8_t const* vector, std::size_t wanted, predicate_at&& predicate, std::size_t thread = any_thread(), bool exact = false, float radius = std::numeric_limits<float>::infinity()) const { return search_(vector, wanted, std::forward<predicate_at>(predicate), thread, exact, radius, casts_.from.i8); }
+    template <typename predicate_at> search_result_t filtered_search(f16_t const* vector, std::size_t wanted, predicate_at&& predicate, std::size_t thread = any_thread(), bool exact = false, float radius = std::numeric_limits<float>::infinity()) const { return search_(vector, wanted, std::forward<predicate_at>(predicate), thread, exact, radius, casts_.from.f16); }
+    template <typename predicate_at> search_result_t filtered_search(bf16_t const* vector, std::size_t wanted, predicate_at&& predicate, std::size_t thread = any_thread(), bool exact = false, float radius = std::numeric_limits<float>::infinity()) const { return search_(vector, wanted, std::forward<predicate_at>(predicate), thread, exact, radius, casts_.from.bf16); }
+    template <typename predicate_at> search_result_t filtered_search(f32_t const* vector, std::size_t wanted, predicate_at&& predicate, std::size_t thread = any_thread(), bool exact = false, float radius = std::numeric_limits<float>::infinity()) const { return search_(vector, wanted, std::forward<predicate_at>(predicate), thread, exact, radius, casts_.from.f32); }
+    template <typename predicate_at> search_result_t filtered_search(f64_t const* vector, std::size_t wanted, predicate_at&& predicate, std::size_t thread = any_thread(), bool exact = false, float radius = std::numeric_limits<float>::infinity()) const { return search_(vector, wanted, std::forward<predicate_at>(predicate), thread, exact, radius, casts_.from.f64); }
 
     std::size_t get(vector_key_t key, b1x8_t* vector, std::size_t vectors_count = 1) const { return get_(key, vector, vectors_count, casts_.to.b1x8); }
     std::size_t get(vector_key_t key, i8_t* vector, std::size_t vectors_count = 1) const { return get_(key, vector, vectors_count, casts_.to.i8); }
@@ -2051,7 +2051,7 @@ class index_dense_gt {
 
     template <typename scalar_at, typename predicate_at>
     search_result_t search_(scalar_at const* vector, std::size_t wanted, predicate_at&& predicate, std::size_t thread,
-                            bool exact, cast_punned_t const& cast) const {
+                            bool exact, float radius, cast_punned_t const& cast) const {
 
         // Cast the vector, if needed for compatibility with `metric_`
         thread_lock_t lock = thread_lock_(thread);
@@ -2067,6 +2067,7 @@ class index_dense_gt {
         search_config.thread = lock.thread_id;
         search_config.expansion = config_.expansion_search;
         search_config.exact = exact;
+        search_config.radius = radius;
 
         vector_key_t free_key_copy = free_key_;
         if (std::is_same<typename std::decay<predicate_at>::type, dummy_predicate_t>::value) {


### PR DESCRIPTION
## Summary

- The change implements the `radius` argument for search across the C++ core and Python wrapper, allowing users to exclude results beyond a maximum distance threshold.
- Adds `float radius` to `index_search_config_t`, threaded through `index_dense_gt::search()` and `filtered_search()` overloads, with post-sort filtering in `index_gt::search()`.
- Wires the existing-but-unused `radius` parameter in Python `Index.search()` through `_search_in_compiled()`, and adds it to `Indexes.search()` and the module-level `search()`.
- Results with `distance > radius` are excluded; `distance == radius` is included. Default is infinity (no filtering, fully backward-compatible).

## Changed files

| File | What |
|---|---|
| `include/usearch/index.hpp` | `radius` field in `index_search_config_t` + filtering after `sort_ascending()`/`shrink()` |
| `include/usearch/index_dense.hpp` | `radius` param on all 12 `search()`/`filtered_search()` overloads + `search_()` |
| `python/usearch/index.py` | `radius` wired through `_search_in_compiled()`, `Index.search()`, `Indexes.search()`, `search()` |
| `cpp/test.cpp` | `test_radius_search()` -- default, tight, zero, and infinite radius with L2sq |
| `python/scripts/test_index.py` | 4 test functions (11 parametrized cases) covering filtering, defaults, edge cases, single/batch |

## Design notes

- **C++ filtering** happens after HNSW traversal completes (post-filter on sorted results), not during traversal;
- **Python filtering** uses `np.searchsorted` on the ascending-sorted distance arrays in `_search_in_compiled()`. This handles both the HNSW and brute-force exact search paths without changing `lib.cpp`;
- `lib.cpp` (pybind11 bindings) is intentionally **not changed** -- the module-level `search(exact=True)` path forwards `**kwargs` to `_exact_search`, which doesn't accept `radius`. Extracting `radius` as a named parameter in `_search_in_compiled()` avoids this cleanly.

## Tests

- [x] C++ `test_radius_search()` passes (default, tight, zero, infinite radius)
- [x] C++ full test suite passes (`build_debug/test_cpp`)
- [x] Python radius tests pass (11/11 cases)
- [x] Python full test suite passes (593 passed, 6 skipped -- skips are pre-existing)