### PR TITLE
Fix Python lib.cpp serialized_length TypeError missing argument

### DIFF
--- a/python/lib.cpp
+++ b/python/lib.cpp
@@ -1236,7 +1236,7 @@ PYBIND11_MODULE(compiled, m) {
     i.def_property_readonly( //
         "dtype", [](dense_index_py_t const& index) -> scalar_kind_t { return index.scalar_kind(); });
 
-    i.def_property_readonly("serialized_length", &dense_index_py_t::serialized_length);
+    i.def_property_readonly("serialized_length", [](dense_index_py_t const& self) -> std::size_t { return self.serialized_length({}); });
     i.def_property_readonly("memory_usage", &dense_index_py_t::memory_usage);
 
     i.def_property("expansion_add", &dense_index_py_t::expansion_add, &dense_index_py_t::change_expansion_add);


### PR DESCRIPTION
As stated in Issue #683, serialized_length raises TypeError as Python callers cannot use the property without passing a config object.

Fix: As suggested by the original issue statement, wrapping serialized_length in a lambda preserves the default behavior and handles the arg mismatch.

After Fixing: idx.serialized_length returns an integer (260)

USearch version
v2.23.0

Operating System: Windows 10 (original bug found in Windows 11)

Python 3.12

Hardware Architecture x86_64

Code of Conduct
I agree to the Code of Conduct and Contributing standards