### PR TITLE
Define MAP_FAILED if not already defined

### DIFF
--- a/include/usearch/index.hpp
+++ b/include/usearch/index.hpp
@@ -77,6 +77,9 @@
 #endif
 #include <Windows.h>
 #include <sys/stat.h> // `fstat` for file size
+#if !defined(MAP_FAILED)
+#define MAP_FAILED ((void *) -1)
+#endif
 #undef NOMINMAX
 #undef _USE_MATH_DEFINES
 #else


### PR DESCRIPTION
#715 Add missing constant MAP_FAILED for Windows.
Can't test this, as I have not Windows.  Just copied what others on github do.