### PR TITLE
Fix: mmap MAP_FAILED not handled correctly on POSIX

### DIFF
--- a/cpp/bench.cpp
+++ b/cpp/bench.cpp
@@ -112,9 +112,10 @@ struct alignas(32) persisted_matrix_gt {
         if (fstat(file_descriptor, &stat_vectors) == -1)
             throw std::invalid_argument("Couldn't obtain file stats");
         raw_length = stat_vectors.st_size;
-        raw_handle = (std::uint8_t*)mmap(NULL, raw_length, PROT_READ, MAP_PRIVATE, file_descriptor, 0);
-        if (raw_handle == nullptr)
+        auto* result = mmap(NULL, raw_length, PROT_READ, MAP_PRIVATE, file_descriptor, 0);
+        if (result == MAP_FAILED)
             throw std::invalid_argument("Couldn't memory-map the file");
+        raw_handle = (std::uint8_t*)result;
         std::memcpy(&rows, raw_handle, sizeof(rows));
         std::memcpy(&cols, raw_handle + sizeof(rows), sizeof(cols));
         scalars = (scalar_t*)(raw_handle + sizeof(rows) + sizeof(cols));

--- a/include/usearch/index_plugins.hpp
+++ b/include/usearch/index_plugins.hpp
@@ -854,7 +854,8 @@ class page_allocator_t {
 #if defined(USEARCH_DEFINED_WINDOWS)
         return (byte_t*)(::VirtualAlloc(NULL, count_bytes, MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE));
 #else
-        return (byte_t*)mmap(NULL, count_bytes, PROT_WRITE | PROT_READ, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+        auto* result = mmap(NULL, count_bytes, PROT_WRITE | PROT_READ, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+        return (result == MAP_FAILED) ? nullptr : (byte_t*)result;
 #endif
     }
 


### PR DESCRIPTION
## Problem

On POSIX, `mmap` returns `MAP_FAILED ((void*)-1)` on failure, not `NULL`: https://man7.org/linux/man-pages/man2/mmap.2.html
Two call sites were incorrectly treating the return value as nullable:

- `index_plugins.hpp: allocate()` cast `mmap` result directly to `byte_t*`  without checking `MAP_FAILED`, returning a garbage pointer instead of `nullptr`
- `bench.cpp: persisted_matrix_gt` checked `== nullptr` instead of `== MAP_FAILED`,
  silently passing on failure and proceeding with an invalid pointer

## Fix

Both are fixed to check MAP_FAILED before casting.