### PR TITLE
Fix: hash set iterator returns deleted tombstones in equal_range

### DIFF
--- a/include/usearch/index_plugins.hpp
+++ b/include/usearch/index_plugins.hpp
@@ -2735,10 +2735,17 @@ class flat_hash_multi_set_gt {
 
         // Pre-increment
         equal_iterator_gt& operator++() {
+            auto should_skip = [&](std::size_t i) -> bool {
+                auto slot = parent_->slot_ref(i);
+                if (!(slot.header.populated & slot.mask))
+                    return false; // empty slot — stop
+                if (slot.header.deleted & slot.mask)
+                    return true; // tombstone — skip
+                return !equals_(slot.element, query_); // skip non-matching live entries
+            };
             do {
                 index_ = (index_ + 1) & (parent_->capacity_slots_ - 1);
-            } while (!equals_(parent_->slot_ref(index_).element, query_) &&
-                     (parent_->slot_ref(index_).header.populated & parent_->slot_ref(index_).mask));
+            } while (should_skip(index_));
             return *this;
         }
 

--- a/include/usearch/index_plugins.hpp
+++ b/include/usearch/index_plugins.hpp
@@ -2733,19 +2733,17 @@ class flat_hash_multi_set_gt {
                           equals_t const& equals)
             : index_(index), parent_(parent), query_(query), equals_(equals) {}
 
-        // Pre-increment
+        // Pre-increment: advance past tombstones and non-matching entries,
+        // stopping at the next matching live entry or an empty slot.
         equal_iterator_gt& operator++() {
-            auto should_skip = [&](std::size_t i) -> bool {
-                auto slot = parent_->slot_ref(i);
-                if (!(slot.header.populated & slot.mask))
-                    return false; // empty slot — stop
-                if (slot.header.deleted & slot.mask)
-                    return true; // tombstone — skip
-                return !equals_(slot.element, query_); // skip non-matching live entries
-            };
             do {
                 index_ = (index_ + 1) & (parent_->capacity_slots_ - 1);
-            } while (should_skip(index_));
+                auto slot = parent_->slot_ref(index_);
+                bool is_empty = ~slot.header.populated & slot.mask;
+                bool is_match = !(slot.header.deleted & slot.mask) && equals_(slot.element, query_);
+                if (is_empty || is_match)
+                    break;
+            } while (true);
             return *this;
         }
 


### PR DESCRIPTION
The equal_range iterator in `flat_hash_multi_set_gt` did not check the deleted flag when advancing. After add/remove cycles that create tombstones with the same key, the iterator would yield deleted entries as live matches. In `index_dense_gt::remove()` this caused already-freed slots to be pushed to `free_keys_` again, inflating `free_keys_.size()` and producing unsigned underflow in `size()`.

Reproduces in both multi and non-multi mode (single-threaded) whenever two keys hash-collide and one tombstone is reused by a different key.

Closes #697