### PR TITLE
Fix: deduplicate neighbor slots in `form_reverse_links_` in `index_gt::update`

### DIFF
--- a/include/usearch/index.hpp
+++ b/include/usearch/index.hpp
@@ -3898,13 +3898,14 @@ class index_gt {
             usearch_assert_m(close_slot != new_slot, "Self-loops are impossible");
             usearch_assert_m(level <= close_node.level(), "Linking to missing level");
 
-            // If `new_slot` is already present in the neighboring connections of `close_slot`
-            // then no need to modify any connections or run the heuristics.
+            // Skip to prevent duplicate entries in the neighbor list.
+            if (std::find_if(close_header.begin(), close_header.end(),
+                             [new_slot](compressed_slot_t slot) { return slot == new_slot; }) != close_header.end()) {
+                continue;
+            }
+
             if (close_header.size() < connectivity_max) {
-                if (std::find_if(close_header.begin(), close_header.end(),
-                                 [new_slot](compressed_slot_t slot) { return slot == new_slot; }) == close_header.end()) {
-                    close_header.push_back(new_slot);
-                }
+                close_header.push_back(new_slot);
                 continue;
             }
 


### PR DESCRIPTION
This PR fixes https://github.com/unum-cloud/USearch/issues/728.

----

- For your reference, if [PR#725](https://github.com/unum-cloud/USearch/pull/725) is merged, I can also add the reproduction test case written in [the issue](https://github.com/unum-cloud/USearch/issues/728) as a new test in index_gt_test.cpp.