### PR TITLE
Fix: Rust cosine metric docstring

### DIFF
--- a/rust/lib.rs
+++ b/rust/lib.rs
@@ -258,7 +258,7 @@ pub mod ffi {
         IP,
         /// The squared Euclidean Distance metric, defined as `L2 = sum((a[i] - b[i])^2)`.
         L2sq,
-        /// The Cosine Similarity metric, defined as `Cos = 1 - sum(a[i] * b[i]) / (sqrt(sum(a[i]^2) * sqrt(sum(b[i]^2)))`.
+        /// The Cosine Distance metric, defined as `Cos = 1 - sum(a[i] * b[i]) / (sqrt(sum(a[i]^2)) * sqrt(sum(b[i]^2)))`.
         Cos,
         /// The Pearson Correlation metric.
         Pearson,


### PR DESCRIPTION
## Summary
- Corrected "Cosine Similarity" to "Cosine Distance" in the Rust `MetricKind::Cos` docstring to match the actual formula
- Fixed mismatched parentheses in the formula: each `sqrt` now has its own closing paren

## Test plan
- [x] Verify `cargo doc` renders the formula correctly
- [x] No code changes, docstring-only fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)