### PR TITLE
Fix: Guard Float16 APIs with #if arch(arm64) in core Swift bindings

### DIFF
--- a/swift/USearchIndex.swift
+++ b/swift/USearchIndex.swift
@@ -422,6 +422,11 @@ public class USearchIndex: NSObject {
         )
     }
 
+    // Float16 is only available on arm64 Apple platforms. The @available annotation
+    // alone is insufficient because Float16 is a type-level absence on x86_64,
+    // not a runtime availability issue. See: https://github.com/unum-cloud/usearch/issues/589
+    #if arch(arm64)
+
     /**
      * @brief Adds a labeled vector to the index.
      * @param vector Half-precision vector.
@@ -494,6 +499,8 @@ public class USearchIndex: NSObject {
             distances: distances
         )
     }
+
+    #endif // arch(arm64)
 
     public func contains(key: USearchKey) throws -> Bool {
         return try throwing { usearch_contains(nativeIndex, key, $0) }


### PR DESCRIPTION
## Summary

- Wraps the four `Float16` methods in `USearchIndex.swift` with `#if arch(arm64)`, matching the existing guard in `USearchIndex+Sugar.swift`
- `Float16` is a type-level absence on x86_64 macOS — `@available` alone (added in #610) is insufficient because the compiler rejects `Float16` before runtime availability checks apply

## Verification

- Builds and archives successfully for `generic/platform=macOS` (universal, including x86_64)
- Did not run `swift test` locally — the change only adds a compile-time guard around existing code

Fixes #589