### PR TITLE
Fix python licence warning

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -208,12 +208,12 @@ setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     license="Apache-2.0",
+    license_files=["LICENSE"],
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Natural Language :: English",
         "Intended Audience :: Developers",
         "Intended Audience :: Information Technology",
-        "License :: OSI Approved :: Apache Software License",
         "Programming Language :: C++",
         "Programming Language :: Python :: 3 :: Only",
         "Programming Language :: Python :: Implementation :: CPython",


### PR DESCRIPTION
Resolve warning during build 
```
              Please consider removing the following classifiers in favor of a SPDX license expression:

              License :: OSI Approved :: Apache Software License

              See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
              ********************************************************************************

```