### PR TITLE
Fix bad paths in build.rs.

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -86,8 +86,8 @@ fn build_usearch() -> Result<(), Box<dyn Error>> {
     println!("cargo:rerun-if-changed=rust/lib.rs");
     println!("cargo:rerun-if-changed=rust/lib.cpp");
     println!("cargo:rerun-if-changed=rust/lib.hpp");
-    println!("cargo:rerun-if-changed=include/index_plugins.hpp");
-    println!("cargo:rerun-if-changed=include/index_dense.hpp");
     println!("cargo:rerun-if-changed=include/usearch/index.hpp");
+    println!("cargo:rerun-if-changed=include/usearch/index_plugins.hpp");
+    println!("cargo:rerun-if-changed=include/usearch/index_dense.hpp");
     Ok(())
 }


### PR DESCRIPTION
Fix some paths in build.rs that were wrong and caused usearch to be perpetually stale on rebuild.