### PR TITLE
fix(python): resolve multi-index search core dumps by exposing missing state (#643)

### DIFF
--- a/python/scripts/test_indexes.py
+++ b/python/scripts/test_indexes.py
@@ -1,0 +1,58 @@
+from usearch.index import Index, Indexes
+import numpy as np
+
+def test_multi_index():
+    print("Initiating Stress Protocol...")
+
+    # ---------------------------------------------------------
+    # Phase 1: The Void Strike (Boundary Conditions)
+    # Proving that an empty Indexes object does not crash the engine.
+    # ---------------------------------------------------------
+    print("Executing Phase 1: Boundary Conditions...")
+    ix_empty = Indexes([])
+    assert ix_empty.ndim == 0, f"Void ndim failed. Expected 0, got {ix_empty.ndim}"
+    assert ix_empty.dtype is None, "Void dtype failed."
+    assert ix_empty.metric == "unknown", f"Void metric failed. Expected 'unknown', got {ix_empty.metric}"
+
+    ndim = 128
+    v1 = np.random.rand(ndim).astype(np.float32)
+    v2 = np.random.rand(ndim).astype(np.float32)
+
+    ia = Index(ndim=ndim)
+    ia.add(100, v1)  # Key 100 holds v1
+
+    ib = Index(ndim=ndim)
+    ib.add(200, v2)  # Key 200 holds v2
+
+    ix = Indexes([ia, ib])
+
+    # ---------------------------------------------------------
+    # Phase 2: The Recall Strike (Mathematical Verification)
+    # Proving the multi-index router searches the correct memory space.
+    # ---------------------------------------------------------
+    print("Executing Phase 2: Recall...")
+    matches = ix.search(v2, count=1)
+    assert len(matches) > 0, "Engine returned empty results."
+    assert matches[0].key == 200, f"Recall failure. Expected 200, got {matches[0].key}"
+    # Distance to itself should be essentially zero
+    assert matches[0].distance < 1e-5, f"Distance variance too high: {matches[0].distance}"
+
+    # ---------------------------------------------------------
+    # Phase 3: The Batch Strike (Memory Alignment)
+    # Proving the wrapper can handle matrices, not just single vectors.
+    # ---------------------------------------------------------
+    print("Executing Phase 3: Batch Memory Alignment...")
+    batch_query = np.vstack([v1, v2]) # Shape: (2, 128)
+    
+    batch_matches = ix.search(batch_query, count=1)
+    assert len(batch_matches) == 2, f"Batch router failed. Expected 2 result sets, got {len(batch_matches)}"
+    
+    # The first query (v1) should return key 100
+    assert batch_matches[0][0].key == 100, f"Batch recall 0 failed. Got {batch_matches[0][0].key}"
+    # The second query (v2) should return key 200
+    assert batch_matches[1][0].key == 200, f"Batch recall 1 failed. Got {batch_matches[1][0].key}"
+
+    print("All assertions passed. The architecture holds.")
+
+if __name__ == "__main__":
+    test_multi_index()

--- a/python/usearch/index.py
+++ b/python/usearch/index.py
@@ -1520,17 +1520,34 @@ class Index:
 class Indexes:
     def __init__(
         self,
-        indexes: Iterable[Index] = [],
-        paths: Iterable[os.PathLike] = [],
+        indexes: Iterable[Index] = None,
+        paths: Iterable[os.PathLike] = None,
         view: bool = False,
         threads: int = 0,
     ) -> None:
+        self.indices = list(indexes) if indexes is not None else []
         self._compiled = _CompiledIndexes()
-        for index in indexes:
+        
+        for index in self.indices:
             self._compiled.merge(index._compiled)
-        self._compiled.merge_paths(paths, view=view, threads=threads)
+            
+        paths_list = list(paths) if paths is not None else []
+        self._compiled.merge_paths(paths_list, view=view, threads=threads)
+
+    @property
+    def ndim(self) -> int:
+        return self.indices[0].ndim if self.indices else 0
+
+    @property
+    def dtype(self) -> Union[ScalarKind, None]:
+        return self.indices[0].dtype if self.indices else None
+
+    @property
+    def metric(self) -> Union[MetricKind, CompiledMetric, str]:
+        return self.indices[0].metric if self.indices else "unknown"
 
     def merge(self, index: Index):
+        self.indices.append(index)
         self._compiled.merge(index._compiled)
 
     def merge_path(self, path: os.PathLike):


### PR DESCRIPTION
### Description
Fixes #643: `Mult-Index Search Doesn't Work in Python`

### Root Cause Analysis
When utilizing the Python bindings for multi-index search, `ix.search(query)` was failing violently via either a Python `ValueError` (dimension mismatch) or a C++ `std::bad_function_call` (core dump). 

This occurred because the `Indexes` wrapper class dropped the state of its underlying `Index` children upon initialization:
1. **Missing Metadata:** The `Indexes` class lacked the `ndim`, `dtype`, and `metric` properties required by `_search_in_compiled`.
2. **Dangling Pointers / GC:** The `Indexes.__init__` method consumed an iterable of `Index` objects, passed their compiled pointers to C++, and then immediately discarded the Python objects. If instantiated with anonymous objects, Python's garbage collector destroyed the underlying indices, leaving the C++ core with null pointers to metric functions (triggering the `std::bad_function_call`).

### The Fix
* Bound the iterable of indices to `self.indices` within the `Indexes` constructor to ensure the Python objects (and their C++ metric callbacks) survive garbage collection.
* Implemented `@property` methods for `ndim`, `dtype`, and `metric` on the `Indexes` class that dynamically inherit the architectural state from the first underlying index in the collection.

### Validation
Added `test_multi_index` to the Python test suite to strictly verify:
* **Boundary Conditions:** Empty `Indexes([])` gracefully returns `0` / `None` / `unknown`.
* **Recall Verification:** Multi-index router successfully locates distinct vectors across different C++ shards.
* **Batch Memory Alignment:** Wrapper successfully handles batch matrix queries (`np.vstack`) across the boundary without dimension mismatch errors.