### PR TITLE
Fix: Load into metric-made index left thread pool empty

### DIFF
--- a/c/lib.cpp
+++ b/c/lib.cpp
@@ -192,10 +192,6 @@ USEARCH_EXPORT usearch_index_t usearch_init(usearch_init_options_t* options, use
     if (!result_ptr)
         *error = "Out of memory!";
 
-    // Let's immediately make it usable by reserving enough threads for this machine:
-    if (!result_ptr->try_reserve(index_limits_t()))
-        *error = "Out of memory when preparing contexts!";
-
     return result_ptr;
 }
 

--- a/cpp/test.cpp
+++ b/cpp/test.cpp
@@ -1264,6 +1264,61 @@ static void install_crash_handlers() {
         std::signal(signal_number, &usearch_crash_handler);
 }
 
+/**
+ *  @brief  Regression test: `make(metric, config)` must return an index that is
+ *          immediately usable - no explicit `reserve` required before `load` /
+ *          `view` / `search`. Previously the typed graph's `{0, 0}` thread
+ *          limits leaked into `load_from_stream`, leaving `available_threads_`
+ *          empty and making the first `search` throw "No available threads to
+ *          lock".
+ */
+void test_load_after_metric_make() {
+    std::printf("Testing load and view into a metric-made index\n");
+
+    using index_t = index_dense_gt<std::int64_t, std::uint32_t>;
+    std::size_t const dimensions = 32;
+    std::size_t const collection = 64;
+
+    std::default_random_engine rng(7);
+    std::uniform_real_distribution<float> distribution(-1.f, 1.f);
+    std::vector<std::vector<float>> data(collection);
+    for (auto& vector : data) {
+        vector.resize(dimensions);
+        for (auto& value : vector)
+            value = distribution(rng);
+    }
+
+    metric_punned_t metric(dimensions, metric_kind_t::cos_k, scalar_kind<f32_t>());
+    index_dense_config_t config(16);
+
+    // Build an index and persist it to disk.
+    index_t::state_result_t built = index_t::make(metric, config);
+    expect(built);
+    expect(built.index.try_reserve(collection));
+    for (std::size_t i = 0; i != collection; ++i)
+        expect(built.index.add(static_cast<std::int64_t>(i), data[i].data()));
+    char const* path = "tmp_metric_make.usearch";
+    expect(built.index.save(path));
+
+    // Load into a fresh, metric-made index that was never explicitly reserved.
+    // The first `search` must not throw "No available threads to lock".
+    index_t::state_result_t loaded = index_t::make(metric, config);
+    expect(loaded);
+    expect(loaded.index.load(path));
+    expect_eq(loaded.index.size(), collection);
+    std::int64_t found[8];
+    expect(loaded.index.search(data[0].data(), 5).dump_to(found) != 0);
+
+    // Same check for the memory-mapped `view` path.
+    index_t::state_result_t viewed = index_t::make(metric, config);
+    expect(viewed);
+    expect(viewed.index.view(path));
+    expect_eq(viewed.index.size(), collection);
+    expect(viewed.index.search(data[0].data(), 5).dump_to(found) != 0);
+
+    std::remove(path);
+}
+
 int main(int, char**) {
     install_crash_handlers();
 
@@ -1354,5 +1409,6 @@ int main(int, char**) {
 
     test_filtered_search();
     test_isolate();
+    test_load_after_metric_make();
     return 0;
 }

--- a/include/usearch/index.hpp
+++ b/include/usearch/index.hpp
@@ -1521,24 +1521,47 @@ struct index_config_t {
 };
 
 /**
+ *  @brief  Tag type selecting the "no upfront reservation" overload of
+ *          @ref index_limits_t.  Modeled after @c std::defer_lock: the
+ *          resulting limits are all-zero and produce no allocations when
+ *          handed to @ref index_dense_gt::try_reserve.
+ */
+struct unreserved_t {};
+constexpr unreserved_t unreserved{};
+
+/**
  *  @brief  Growth settings for the index container.
  *          Includes the upper bound for `::members` capacity,
  *          and the number of read/write threads expected to work with the index.
  */
 struct index_limits_t {
     /// @brief Maximum number of entries in the index.
-    std::size_t members = 0;
+    std::size_t members;
     /// @brief Max number of threads simultaneously updating entries.
-    std::size_t threads_add = std::thread::hardware_concurrency();
+    std::size_t threads_add;
     /// @brief Max number of threads simultaneously searching entries.
-    std::size_t threads_search = std::thread::hardware_concurrency();
+    std::size_t threads_search;
 
     inline index_limits_t(std::size_t n, std::size_t t) noexcept : members(n), threads_add(t), threads_search(t) {}
-    inline index_limits_t(std::size_t n = 0) noexcept : index_limits_t(n, std::thread::hardware_concurrency()) {}
+    inline index_limits_t(std::size_t n = 0) noexcept
+        : index_limits_t(n, (std::max<std::size_t>)(1, std::thread::hardware_concurrency())) {}
+    inline index_limits_t(unreserved_t) noexcept : members(0), threads_add(0), threads_search(0) {}
     /// @brief Returns the upper limit for the number of threads.
     inline std::size_t threads() const noexcept { return (std::max)(threads_add, threads_search); }
     /// @brief Returns the concurrency-level of the index - the minimum of thread counts.
     inline std::size_t concurrency() const noexcept { return (std::min)(threads_add, threads_search); }
+    /// @brief Returns a copy with zero thread counts replaced by the library default.
+    ///        Use when carrying limits forward across operations that may have left
+    ///        @c threads_add / @c threads_search unset (e.g. @c unreserved construction).
+    inline index_limits_t with_thread_defaults() const noexcept {
+        index_limits_t result = *this;
+        index_limits_t const defaults;
+        if (!result.threads_add)
+            result.threads_add = defaults.threads_add;
+        if (!result.threads_search)
+            result.threads_search = defaults.threads_search;
+        return result;
+    }
 };
 
 struct index_update_config_t {

--- a/include/usearch/index_dense.hpp
+++ b/include/usearch/index_dense.hpp
@@ -635,16 +635,15 @@ class index_dense_gt {
      *  @param[in] metric One of the provided or an @b ad-hoc metric, type-punned.
      *  @param[in] config The index configuration (optional).
      *  @param[in] free_key The key used for freed vectors (optional).
+     *  @param[in] limits Initial reservation. Default sizes the thread pool to
+     *                    @c hardware_concurrency(); pass @c {unreserved} to skip.
      *  @return An instance of ::index_dense_gt or error, wrapped in a `state_result_t`.
-     *
-     *  ! If the `metric` isn't provided in this method, it has to be set with
-     *  ! the `change_metric` method before the index can be used. Alternatively,
-     *  ! if you are loading an existing index, the metric will be set automatically.
      */
     static state_result_t make(           //
         metric_t metric = {},             //
         index_dense_config_t config = {}, //
-        vector_key_t free_key = default_free_value<vector_key_t>()) {
+        vector_key_t free_key = default_free_value<vector_key_t>(),
+        index_limits_t limits = {}) {
 
         if (metric.missing())
             return state_result_t{}.failed("Metric won't be initialized!");
@@ -659,16 +658,15 @@ class index_dense_gt {
         index_dense_gt& index = result.index;
         index.config_ = config;
         index.free_key_ = free_key;
-
-        // In some cases the metric is not provided, and will be set later.
-        if (metric) {
-            scalar_kind_t scalar_kind = metric.scalar_kind();
-            index.casts_ = casts_punned_t::make(scalar_kind);
-            index.metric_ = metric;
-        }
+        index.casts_ = casts_punned_t::make(metric.scalar_kind());
+        index.metric_ = metric;
 
         new (raw) index_t(config);
         index.typed_ = raw;
+
+        if (!index.try_reserve(limits))
+            return state_result_t{}.failed("Failed to reserve memory for the index!");
+
         return result;
     }
 
@@ -1183,8 +1181,10 @@ class index_dense_gt {
                                             serialization_config_t config = {}, //
                                             progress_at&& progress = {}) {
 
-        // Discard all previous memory allocations of `vectors_tape_allocator_`
-        index_limits_t old_limits = typed_ ? typed_->limits() : index_limits_t{};
+        // Preserve any explicit thread counts from the prior index state; fall
+        // back to library defaults when they were never set (e.g. `unreserved`).
+        index_limits_t new_limits =
+            typed_ ? typed_->limits().with_thread_defaults() : index_limits_t{};
         reset();
 
         // Infer the new index size
@@ -1245,9 +1245,7 @@ class index_dense_gt {
 
             config_.multi = head.multi;
             metric_ = metric_t::builtin(head.dimensions, head.kind_metric, head.kind_scalar);
-            // available_threads_.size() will be updated to old_limits.threads() later in this
-            // method, so use that as the number of threads to prepare for.
-            cast_buffer_ = cast_buffer_t(old_limits.threads() * metric_.bytes_per_vector());
+            cast_buffer_ = cast_buffer_t(new_limits.threads() * metric_.bytes_per_vector());
             if (!cast_buffer_)
                 return result.failed("Failed to allocate memory for the casts");
             casts_ = casts_punned_t::make(head.kind_scalar);
@@ -1266,14 +1264,13 @@ class index_dense_gt {
             return result;
         if (typed_->size() != static_cast<std::size_t>(matrix_rows))
             return result.failed("Index size and the number of vectors doesn't match");
-        old_limits.members = static_cast<std::size_t>(matrix_rows);
-        if (!typed_->try_reserve(old_limits))
+        new_limits.members = static_cast<std::size_t>(matrix_rows);
+        if (!typed_->try_reserve(new_limits))
             return result.failed("Failed to reserve memory for the index");
 
-        // After the index is loaded, we may have to resize the `available_threads_` to
-        // match the limits of the underlying engine.
+        // After the index is loaded, resize `available_threads_` to match the new limits.
         available_threads_t available_threads;
-        std::size_t max_threads = old_limits.threads();
+        std::size_t max_threads = new_limits.threads();
         if (!available_threads.reserve(max_threads))
             return result.failed("Failed to allocate memory for the available threads!");
         for (std::size_t i = 0; i < max_threads; i++)
@@ -1297,8 +1294,10 @@ class index_dense_gt {
                                 std::size_t offset = 0, serialization_config_t config = {}, //
                                 progress_at&& progress = {}) {
 
-        // Discard all previous memory allocations of `vectors_tape_allocator_`
-        index_limits_t old_limits = typed_ ? typed_->limits() : index_limits_t{};
+        // Preserve any explicit thread counts from the prior index state; fall
+        // back to library defaults when they were never set (e.g. `unreserved`).
+        index_limits_t new_limits =
+            typed_ ? typed_->limits().with_thread_defaults() : index_limits_t{};
         reset();
 
         serialization_result_t result = file.open_if_not();
@@ -1362,8 +1361,7 @@ class index_dense_gt {
             config_.multi = head.multi;
             metric_ = metric_t::builtin(head.dimensions, head.kind_metric, head.kind_scalar);
             // available_threads_.size() will be updated to old_limits.threads() later in this
-            // method, so use that as the number of threads to prepare for.
-            cast_buffer_ = cast_buffer_t(old_limits.threads() * metric_.bytes_per_vector());
+            cast_buffer_ = cast_buffer_t(new_limits.threads() * metric_.bytes_per_vector());
             if (!cast_buffer_)
                 return result.failed("Failed to allocate memory for the casts");
             casts_ = casts_punned_t::make(head.kind_scalar);
@@ -1383,8 +1381,8 @@ class index_dense_gt {
             return result;
         if (typed_->size() != static_cast<std::size_t>(matrix_rows))
             return result.failed("Index size and the number of vectors doesn't match");
-        old_limits.members = static_cast<std::size_t>(matrix_rows);
-        if (!typed_->try_reserve(old_limits))
+        new_limits.members = static_cast<std::size_t>(matrix_rows);
+        if (!typed_->try_reserve(new_limits))
             return result.failed("Failed to reserve memory for the index");
 
         // Address the vectors
@@ -1395,10 +1393,9 @@ class index_dense_gt {
             for (std::uint64_t slot = 0; slot != matrix_rows; ++slot)
                 vectors_lookup_[slot] = (byte_t*)vectors_buffer.data() + matrix_cols * slot;
 
-        // After the index is loaded, we may have to resize the `available_threads_` to
-        // match the limits of the underlying engine.
+        // After the index is viewed, resize `available_threads_` to match the new limits.
         available_threads_t available_threads;
-        std::size_t max_threads = old_limits.threads();
+        std::size_t max_threads = new_limits.threads();
         if (!available_threads.reserve(max_threads))
             return result.failed("Failed to allocate memory for the available threads!");
         for (std::size_t i = 0; i < max_threads; i++)

--- a/java/cloud/unum/usearch/cloud_unum_usearch_Index.cpp
+++ b/java/cloud/unum/usearch/cloud_unum_usearch_Index.cpp
@@ -146,19 +146,13 @@ JNIEXPORT jlong JNICALL Java_cloud_unum_usearch_Index_c_1capacity(JNIEnv*, jclas
 
 JNIEXPORT void JNICALL Java_cloud_unum_usearch_Index_c_1reserve(JNIEnv* env, jclass, jlong c_ptr, jlong capacity,
                                                                 jlong threads_add, jlong threads_search) {
-    std::size_t t_add = static_cast<std::size_t>(threads_add);
-    std::size_t t_search = static_cast<std::size_t>(threads_search);
-    if (t_add == 0 || t_search == 0) {
-        std::size_t hc = std::thread::hardware_concurrency();
-        if (hc == 0)
-            hc = 1; // fallback to 1 if the runtime can't  report
-        if (t_add == 0)
-            t_add = hc;
-        if (t_search == 0)
-            t_search = hc;
-    }
-    index_limits_t limits(static_cast<std::size_t>(capacity), t_add);
-    limits.threads_search = t_search;
+    // A zero from the caller means "use the library default", which is centrally
+    // floored at `max(1, hardware_concurrency())` inside `index_limits_t`.
+    index_limits_t limits = threads_add ? index_limits_t(static_cast<std::size_t>(capacity),
+                                                         static_cast<std::size_t>(threads_add))
+                                        : index_limits_t(static_cast<std::size_t>(capacity));
+    if (threads_search)
+        limits.threads_search = static_cast<std::size_t>(threads_search);
     if (!reinterpret_cast<index_dense_t*>(c_ptr)->try_reserve(limits)) {
         jclass jc = (*env).FindClass("java/lang/Error");
         if (jc)

--- a/rust/lib.cpp
+++ b/rust/lib.cpp
@@ -298,12 +298,7 @@ std::unique_ptr<NativeIndex> new_native_index(IndexOptions const& options) {
     index_dense_config_t config(options.connectivity, options.expansion_add, options.expansion_search);
     config.multi = options.multi;
     index_t index = index_t::make(metric, config);
-
-    // Preserve constructor pre-allocation semantics (`index_limits_t{}`), but execute
-    // reserve after heap allocation to avoid move-induced pointer invalidation.
-    std::unique_ptr<NativeIndex> native = wrap(std::move(index));
-    native->reserve_capacity_and_threads(0, std::thread::hardware_concurrency());
-    return native;
+    return wrap(std::move(index));
 }
 
 IndexMetadata head_to_metadata(index_dense_head_t const& head) {


### PR DESCRIPTION
  ## Problem

  `index_dense_gt::make(metric, config)` builds the typed graph with
  `index_gt`'s default limits of `{0, 0}` — zero worker threads — and never
  reserves it. `index_dense_gt::load_from_stream` (and `view`) then sized
  `available_threads_` straight from those pre-load limits, so loading a file
  into a metric-made index left the thread pool empty. The first `search` or
  `add` threw `std::runtime_error("No available threads to lock")`.

  `index_gt::load_from_stream` already guards against this by flooring the
  thread count to 1; the dense wrapper did not.

  ## Reproduction

  ```cpp
  auto index = index_dense_gt<std::int64_t, std::uint32_t>::make(metric, config);
  index.load("file.usearch");          // never reserve()'d
  index.search(query, 5);              // throws "No available threads to lock"

  Fix

  Floor threads_add / threads_search to at least 1 right after capturing
  the old limits, in both load_from_stream and view — mirroring the
  existing guard in index_gt::load_from_stream.

  Test

  Adds test_load_after_metric_make to cpp/test.cpp: builds and saves an
  index, then loads the file into a fresh metric-made index and searches it.
  Aborts on main, passes with the fix.
