### PR TITLE
fix(add/update): bound-check contexts_ before indexing into it

### DIFF
--- a/include/usearch/index.hpp
+++ b/include/usearch/index.hpp
@@ -2436,6 +2436,14 @@ class index_gt {
     /// @brief  Array of thread-specific buffers for temporary data.
     mutable buffer_gt<context_t, contexts_allocator_t> contexts_{};
 
+    context_t* context_or_null_(std::size_t thread) noexcept {
+        return thread < contexts_.size() ? contexts_.data() + thread : nullptr;
+    }
+
+    context_t const* context_or_null_(std::size_t thread) const noexcept {
+        return thread < contexts_.size() ? contexts_.data() + thread : nullptr;
+    }
+
   public:
     std::size_t connectivity() const noexcept { return config_.connectivity; }
     std::size_t capacity() const noexcept { return nodes_capacity_; }
@@ -3049,7 +3057,10 @@ class index_gt {
             return result.failed("Can't add to an immutable index");
 
         // Make sure we have enough local memory to perform this request
-        context_t& context = contexts_[config.thread];
+        context_t* context_ptr = context_or_null_(config.thread);
+        if (!context_ptr)
+            return result.failed("Reserve capacity ahead of insertions!");
+        context_t& context = *context_ptr;
         top_candidates_t& top = context.top_candidates;
         next_candidates_t& next = context.next_candidates;
         top.clear();
@@ -3187,7 +3198,10 @@ class index_gt {
         compressed_slot_t updated_slot = iterator.slot_;
 
         // Make sure we have enough local memory to perform this request
-        context_t& context = contexts_[config.thread];
+        context_t* context_ptr = context_or_null_(config.thread);
+        if (!context_ptr)
+            return result.failed("Reserve capacity ahead of updates!");
+        context_t& context = *context_ptr;
         top_candidates_t& top = context.top_candidates;
         next_candidates_t& next = context.next_candidates;
         top.clear();

--- a/include/usearch/index_dense.hpp
+++ b/include/usearch/index_dense.hpp
@@ -532,6 +532,9 @@ class index_dense_gt {
             : parent(other.parent), thread_id(other.thread_id), engaged(other.engaged) {
             other.engaged = false;
         }
+        explicit operator bool() const noexcept {
+            return parent.typed_ && thread_id != any_thread() && thread_id < parent.typed_->limits().threads();
+        }
     };
 
   public:
@@ -996,6 +999,8 @@ class index_dense_gt {
 
         index_cluster_config_t cluster_config;
         thread_lock_t lock = thread_lock_(thread);
+        if (!lock)
+            return cluster_result_t{}.failed("Reserve capacity ahead of searches!");
         cluster_config.thread = lock.thread_id;
         cluster_config.expansion = config_.expansion_search;
         metric_proxy_t metric{*this};
@@ -2107,10 +2112,9 @@ class index_dense_gt {
         if (thread_id != any_thread())
             return {*this, thread_id, false};
 
-        available_threads_mutex_.lock();
-        usearch_assert_m(available_threads_.size(), "No available threads to lock");
-        available_threads_.try_pop(thread_id);
-        available_threads_mutex_.unlock();
+        std::unique_lock<std::mutex> lock(available_threads_mutex_);
+        if (!available_threads_.try_pop(thread_id))
+            return {*this, any_thread(), false};
         return {*this, thread_id, true};
     }
 
@@ -2131,6 +2135,8 @@ class index_dense_gt {
 
         // Cast the vector, if needed for compatibility with `metric_`
         thread_lock_t lock = thread_lock_(thread);
+        if (!lock)
+            return add_result_t{}.failed("Reserve capacity ahead of insertions!");
         byte_t const* vector_data = reinterpret_cast<byte_t const*>(vector);
         {
             byte_t* casted_data = cast_buffer_.data() + metric_.bytes_per_vector() * lock.thread_id;
@@ -2184,6 +2190,8 @@ class index_dense_gt {
 
         // Cast the vector, if needed for compatibility with `metric_`
         thread_lock_t lock = thread_lock_(thread);
+        if (!lock)
+            return search_result_t{*this}.failed("Reserve capacity ahead of searches!");
         byte_t const* vector_data = reinterpret_cast<byte_t const*>(vector);
         {
             byte_t* casted_data = cast_buffer_.data() + metric_.bytes_per_vector() * lock.thread_id;
@@ -2220,6 +2228,8 @@ class index_dense_gt {
 
         // Cast the vector, if needed for compatibility with `metric_`
         thread_lock_t lock = thread_lock_(thread);
+        if (!lock)
+            return cluster_result_t{}.failed("Reserve capacity ahead of searches!");
         byte_t const* vector_data = reinterpret_cast<byte_t const*>(vector);
         {
             byte_t* casted_data = cast_buffer_.data() + metric_.bytes_per_vector() * lock.thread_id;
@@ -2244,6 +2254,8 @@ class index_dense_gt {
 
         // Cast the vector, if needed for compatibility with `metric_`
         thread_lock_t lock = thread_lock_(thread);
+        if (!lock)
+            return {};
         byte_t const* vector_data = reinterpret_cast<byte_t const*>(vector);
         {
             byte_t* casted_data = cast_buffer_.data() + metric_.bytes_per_vector() * lock.thread_id;


### PR DESCRIPTION
After a failed `load_from_stream` (or any path that ends in `index_gt::reset()`), `contexts_` is empty but `is_immutable()` is still false. The very next `add()` then read `contexts_[0]` out of a zero-size buffer — UBSan flagged the null reference and ASAN SEGV'd inside the clear() chain that followed.

Adds an explicit `contexts_.size() <= config.thread` guard at the top of both `add()` and `update()`, returning the same "Reserve capacity ahead of insertions" error the existing capacity-check uses elsewhere. `search()` already handled this case via its own null-data check.