### PR TITLE
fix(clear): preserve capacity contract to avoid use-after-clear segv

### DIFF
--- a/include/usearch/index_dense.hpp
+++ b/include/usearch/index_dense.hpp
@@ -1058,7 +1058,8 @@ class index_dense_gt {
         std::unique_lock<std::mutex> free_lock(free_keys_mutex_);
         typed_->clear();
         slot_lookup_.clear();
-        vectors_lookup_.reset();
+        // Tape pointers are about to be invalidated by the reset below.
+        std::fill(vectors_lookup_.begin(), vectors_lookup_.end(), nullptr);
         free_keys_.clear();
         vectors_tape_allocator_.reset();
     }


### PR DESCRIPTION
`index_dense_gt::clear()` documents that it zeroes `size()` while keeping `capacity()`. In practice it called `vectors_lookup_.reset()`, freeing the per-slot pointer table entirely. The very next `add()` then dereferenced a null `vectors_lookup_[slot]` (UBSan: type mismatch on a null pointer) before any caller had a chance to re-reserve.

Replaces the `reset()` with `memset` over the existing buffer: the pointers it held are stale because `vectors_tape_allocator_` is being reset on the next line, but the buffer itself stays the right size so subsequent `add()` calls land in valid memory.