### PR TITLE
fix(rename): short-circuit `from == to` to avoid an infinite loop

### DIFF
--- a/include/usearch/index_dense.hpp
+++ b/include/usearch/index_dense.hpp
@@ -1683,6 +1683,11 @@ class index_dense_gt {
      */
     labeling_result_t rename(vector_key_t from, vector_key_t to) {
         labeling_result_t result;
+        if (from == to) {
+            result.completed = count(from);
+            return result;
+        }
+
         unique_lock_t lookup_lock(slot_lookup_mutex_);
 
         if (!multi() && slot_lookup_.contains(key_and_slot_t::any_slot(to)))


### PR DESCRIPTION
In a multi-vector index, `rename(from, from)` entered an infinite loop: each iteration popped one `{from, slot}` entry, immediately re-emplaced it as `{to == from, slot}`, and the next `pop_first(from)` happily picked up the just-inserted copy. The fuzzer timed out on the path.

Returns success with `result.completed == 0` when `from == to`.