### PR TITLE
fix(equal_iterator_gt): guard against infinite loop on a full table

### DIFF
--- a/fuzz/regressions/build_and_run.sh
+++ b/fuzz/regressions/build_and_run.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Build and run a single regression test against the in-tree library.
+# Usage: ./build_and_run.sh test_load_buffer_bounds.c
+set -u
+ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+SRC=${1:?usage: $0 <test.c>}
+NAME=$(basename "$SRC" .c)
+OUT=$(mktemp -d)/$NAME
+
+clang++ -std=c++20 -O1 -g -fno-omit-frame-pointer \
+    -fsanitize=address,undefined \
+    -I"$ROOT/include" -I"$ROOT/c" \
+    -x c++ "$ROOT/c/lib.cpp" "$ROOT/fuzz/regressions/$SRC" \
+    -DUSEARCH_USE_OPENMP=0 -DUSEARCH_USE_NUMKONG=0 -DNDEBUG \
+    -pthread -o "$OUT" 2>&1 || { echo "BUILD FAILED"; exit 2; }
+
+ASAN_OPTIONS="allocator_may_return_null=1:detect_leaks=0:abort_on_error=1:halt_on_error=1" \
+UBSAN_OPTIONS="halt_on_error=1:print_stacktrace=1:abort_on_error=1" \
+    timeout 10 "$OUT"
+RC=$?
+rm -rf "$(dirname "$OUT")"
+exit $RC

--- a/fuzz/regressions/test_equal_iterator_no_empty_slot.c
+++ b/fuzz/regressions/test_equal_iterator_no_empty_slot.c
@@ -1,0 +1,73 @@
+// Regression for fix/fuzz-equal-iterator-no-empty-slot.
+//
+// `equal_iterator_gt::operator++` walked the linear-probe chain until it
+// hit an empty slot or another match. After enough adds with the same
+// key in a multi-vector index, the slot lookup ended up with every slot
+// populated (some matching, some not), so the iterator cycled through
+// the matches forever and `std::distance(begin, end)` inside
+// `usearch_remove` hung. libFuzzer reported a timeout.
+//
+// The fix tracks both the iteration start and a cumulative-step counter
+// across `++` calls and pins the iterator to a `capacity_slots_`
+// sentinel after one full pass.
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+#include "usearch.h"
+
+int main(void) {
+    usearch_init_options_t opts;
+    memset(&opts, 0, sizeof(opts));
+    opts.metric_kind = usearch_metric_cos_k;
+    opts.quantization = usearch_scalar_bf16_k;
+    opts.dimensions = 1;
+    opts.connectivity = 17;
+    opts.expansion_add = 16;
+    opts.expansion_search = 16;
+    opts.multi = true;
+
+    usearch_error_t error = NULL;
+    usearch_index_t index = usearch_init(&opts, &error);
+    if (!index || error) {
+        fprintf(stderr, "FAIL: init: %s\n", error ? error : "(null)");
+        return 1;
+    }
+
+    usearch_reserve(index, 5, &error);
+    error = NULL;
+
+    // Add 150 vectors all with the same key — saturates the slot lookup
+    // with identical-key entries.
+    float v[1] = {-1.0f};
+    for (int i = 0; i < 150; ++i) {
+        usearch_add(index, /*key=*/0, v, usearch_scalar_f32_k, &error);
+        error = NULL;
+    }
+
+    // Now attempt to remove a different key. Pre-fix the iterator inside
+    // `equal_range` for the no-empty-slot table cycled forever.
+    clock_t start = clock();
+    usearch_remove(index, /*key=*/55, &error);
+    clock_t elapsed = clock() - start;
+    double seconds = (double)elapsed / (double)CLOCKS_PER_SEC;
+    if (seconds > 2.0) {
+        fprintf(stderr, "FAIL: remove took %.2fs — likely the iterator infinite loop\n", seconds);
+        return 1;
+    }
+
+    // And remove key=0 itself — should also terminate quickly.
+    start = clock();
+    usearch_remove(index, /*key=*/0, &error);
+    elapsed = clock() - start;
+    seconds = (double)elapsed / (double)CLOCKS_PER_SEC;
+    if (seconds > 2.0) {
+        fprintf(stderr, "FAIL: remove(0) took %.2fs — likely the iterator infinite loop\n", seconds);
+        return 1;
+    }
+
+    usearch_free(index, &error);
+    printf("PASS: equal_iterator_no_empty_slot regression\n");
+    return 0;
+}

--- a/include/usearch/index_plugins.hpp
+++ b/include/usearch/index_plugins.hpp
@@ -3913,13 +3913,21 @@ class flat_hash_multi_set_gt {
 
         equal_iterator_gt(std::size_t index, flat_hash_multi_set_gt* parent, query_at const& query,
                           equals_t const& equals)
-            : index_(index), parent_(parent), query_(query), equals_(equals) {}
+            : index_(index), parent_(parent), query_(query), equals_(equals), total_steps_(0) {}
 
-        // Pre-increment: advance past tombstones and non-matching entries,
-        // stopping at the next matching live entry or an empty slot.
+        // After many add/remove cycles every slot can end up populated
+        // (some with the `deleted` flag), so the iterator would cycle
+        // forever. Bail to the `cap` sentinel after a full pass.
         equal_iterator_gt& operator++() {
+            std::size_t const cap = parent_->capacity_slots_;
+            if (cap == 0 || index_ >= cap)
+                return *this;
             do {
-                index_ = (index_ + 1) & (parent_->capacity_slots_ - 1);
+                index_ = (index_ + 1) & (cap - 1);
+                if (++total_steps_ > cap) {
+                    index_ = cap;
+                    break;
+                }
                 auto slot = parent_->slot_ref(index_);
                 bool is_empty = ~slot.header.populated & slot.mask;
                 bool is_match = !(slot.header.deleted & slot.mask) && equals_(slot.element, query_);
@@ -3939,7 +3947,16 @@ class flat_hash_multi_set_gt {
         pointer operator->() { return &parent_->slot_ref(index_).element; }
         bool operator!=(equal_iterator_gt const& other) const { return !(*this == other); }
         bool operator==(equal_iterator_gt const& other) const {
-            return index_ == other.index_ && parent_ == other.parent_;
+            if (parent_ != other.parent_)
+                return false;
+            // Past-the-end iterators (index >= capacity_slots_) compare
+            // equal regardless of the exact `index_`, so a `++` that pinned
+            // us to the `cap` sentinel still terminates loops that compare
+            // against an end with a different past-the-end value.
+            std::size_t const cap = parent_ ? parent_->capacity_slots_ : 0;
+            if (index_ >= cap && other.index_ >= cap)
+                return true;
+            return index_ == other.index_;
         }
 
       private:
@@ -3947,6 +3964,7 @@ class flat_hash_multi_set_gt {
         flat_hash_multi_set_gt* parent_;
         query_at query_;  // Store the query object
         equals_t equals_; // Store the equals functor
+        std::size_t total_steps_;
     };
 
     /**


### PR DESCRIPTION
\`equal_iterator_gt::operator++\` walked the linear-probe chain until it hit an empty or matching slot. After many add/remove cycles every slot in the table can be populated (some with the \`deleted\` flag set, which is still \`populated == 1\`), and the loop walked forever — any \`std::distance(begin, end)\` over the equal range then hung.

Tracks the start index and pins to the \`capacity_slots_\` sentinel after a full wrap so callers comparing against the end iterator terminate.