### PR TITLE
Bundle NumKong runtime with C# native artifacts

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -137,6 +137,7 @@ jobs:
         run: |
           mkdir -p "${{ github.workspace }}/csharp/lib/runtimes/linux-x64/native"
           cp "${{ github.workspace }}/build_artifacts/libusearch_c.so" "${{ github.workspace }}/csharp/lib/runtimes/linux-x64/native"
+          cp "${{ github.workspace }}/build_artifacts/numkong/libnumkong.so" "${{ github.workspace }}/csharp/lib/runtimes/linux-x64/native"
           dotnet test -c Debug --logger "console;verbosity=detailed"
         shell: bash
         working-directory: ${{ github.workspace }}/csharp
@@ -218,6 +219,7 @@ jobs:
         run: |
           mkdir -p "${{ github.workspace }}/csharp/lib/runtimes/linux-x64/native"
           cp "${{ github.workspace }}/build_artifacts/libusearch_c.so" "${{ github.workspace }}/csharp/lib/runtimes/linux-x64/native"
+          cp "${{ github.workspace }}/build_artifacts/numkong/libnumkong.so" "${{ github.workspace }}/csharp/lib/runtimes/linux-x64/native"
           dotnet test -c Debug --logger "console;verbosity=detailed"
         shell: bash
         working-directory: ${{ github.workspace }}/csharp
@@ -307,8 +309,8 @@ jobs:
         # C/C++
       - name: Build C/C++
         run: |
-          choco install cmake
-          cmake -B build_artifacts -D CMAKE_BUILD_TYPE=RelWithDebInfo -D USEARCH_BUILD_TEST_CPP=1 -D USEARCH_BUILD_TEST_C=1 -D USEARCH_BUILD_LIB_C=1 -D USEARCH_BUILD_SQLITE=0
+          choco install cmake -y
+          cmake -B build_artifacts -D CMAKE_BUILD_TYPE=RelWithDebInfo -D USEARCH_BUILD_TEST_CPP=1 -D USEARCH_BUILD_TEST_C=1 -D USEARCH_BUILD_LIB_C=1 -D USEARCH_BUILD_SQLITE=0 -D USEARCH_USE_NUMKONG=1
           cmake --build build_artifacts --config RelWithDebInfo
       - name: Test C++
         run: .\build_artifacts\test_cpp.exe
@@ -353,11 +355,13 @@ jobs:
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
       - name: Test .NET
+        shell: pwsh
         run: |
-          mkdir -p "${{ github.workspace }}\csharp\lib\runtimes\win-x64\native"
-          cp "${{ github.workspace }}\build_artifacts\libusearch_c.dll" "${{ github.workspace }}\csharp\lib\runtimes\win-x64\native"
+          $nativeDir = "${{ github.workspace }}\csharp\lib\runtimes\win-x64\native"
+          New-Item -ItemType Directory -Force -Path $nativeDir | Out-Null
+          Copy-Item "${{ github.workspace }}\build_artifacts\libusearch_c.dll" -Destination $nativeDir
+          Copy-Item "${{ github.workspace }}\build_artifacts\numkong.dll" -Destination $nativeDir
           dotnet test -c Debug --logger "console;verbosity=detailed"
-        shell: bash
         working-directory: ${{ github.workspace }}/csharp
 
   test_windows_arm:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1136,6 +1136,7 @@ jobs:
           cmake --build build_artifacts --config Release
           mkdir -p "${{ github.workspace }}/csharp/lib/runtimes/linux-x64/native"
           cp "${{ github.workspace }}/build_artifacts/libusearch_c.so" "${{ github.workspace }}/csharp/lib/runtimes/linux-x64/native"
+          cp "${{ github.workspace }}/build_artifacts/numkong/libnumkong.so" "${{ github.workspace }}/csharp/lib/runtimes/linux-x64/native"
 
       - name: Build C library for MacOS
         if: matrix.os == 'macos-15'
@@ -1146,15 +1147,19 @@ jobs:
           cmake --build build_artifacts --config Release
           mkdir -p "${{ github.workspace }}/csharp/lib/runtimes/osx-arm64/native"
           cp "${{ github.workspace }}/build_artifacts/libusearch_c.dylib" "${{ github.workspace }}/csharp/lib/runtimes/osx-arm64/native"
+          cp "${{ github.workspace }}/build_artifacts/numkong/libnumkong.dylib" "${{ github.workspace }}/csharp/lib/runtimes/osx-arm64/native"
 
       - name: Build C library for Windows
         if: matrix.os == 'windows-2022'
+        shell: pwsh
         run: |
-          choco install cmake
-          cmake -B build_artifacts -DCMAKE_BUILD_TYPE=Release -DUSEARCH_BUILD_TEST_CPP=0 -DUSEARCH_BUILD_TEST_C=0 -DUSEARCH_BUILD_LIB_C=1 -DUSEARCH_USE_OPENMP=0 -DUSEARCH_USE_NUMKONG=0 -DUSEARCH_USE_JEMALLOC=0
+          choco install cmake -y
+          cmake -B build_artifacts -DCMAKE_BUILD_TYPE=Release -DUSEARCH_BUILD_TEST_CPP=0 -DUSEARCH_BUILD_TEST_C=0 -DUSEARCH_BUILD_LIB_C=1 -DUSEARCH_USE_OPENMP=0 -DUSEARCH_USE_NUMKONG=1 -DUSEARCH_USE_JEMALLOC=0
           cmake --build build_artifacts --config Release
-          mkdir -p "${{ github.workspace }}\csharp\lib\runtimes\win-x64\native"
-          cp "${{ github.workspace }}\build_artifacts\libusearch_c.dll" "${{ github.workspace }}\csharp\lib\runtimes\win-x64\native"
+          $nativeDir = "${{ github.workspace }}\csharp\lib\runtimes\win-x64\native"
+          New-Item -ItemType Directory -Force -Path $nativeDir | Out-Null
+          Copy-Item "${{ github.workspace }}\build_artifacts\libusearch_c.dll" -Destination $nativeDir
+          Copy-Item "${{ github.workspace }}\build_artifacts\numkong.dll" -Destination $nativeDir
 
       - name: Upload Artifacts
         uses: actions/upload-artifact@v5
@@ -1187,6 +1192,15 @@ jobs:
           pattern: usearch-csharp-dependencies-*
           merge-multiple: true
           path: ${{ env.USEARCH_LIBS }}
+
+      - name: Verify native package inputs
+        run: |
+          test -f "${{ env.USEARCH_LIBS }}/runtimes/linux-x64/native/libusearch_c.so"
+          test -f "${{ env.USEARCH_LIBS }}/runtimes/linux-x64/native/libnumkong.so"
+          test -f "${{ env.USEARCH_LIBS }}/runtimes/osx-arm64/native/libusearch_c.dylib"
+          test -f "${{ env.USEARCH_LIBS }}/runtimes/osx-arm64/native/libnumkong.dylib"
+          test -f "${{ env.USEARCH_LIBS }}/runtimes/win-x64/native/libusearch_c.dll"
+          test -f "${{ env.USEARCH_LIBS }}/runtimes/win-x64/native/numkong.dll"
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v5

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -379,6 +379,21 @@ function (setup_target TARGET_NAME)
     if (USEARCH_USE_NUMKONG AND TARGET nk_shared)
         target_compile_definitions(${TARGET_NAME} PRIVATE "NK_DYNAMIC_DISPATCH=1")
         target_link_libraries(${TARGET_NAME} PRIVATE nk_shared)
+
+        # Keep NumKong discoverable both in the build tree (`build/numkong`) and
+        # after packaging it next to `libusearch_c` in language bindings.
+        if (APPLE)
+            set(_USEARCH_NUMKONG_RPATH "@loader_path;@loader_path/numkong")
+        elseif (UNIX AND NOT CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
+            set(_USEARCH_NUMKONG_RPATH "$ORIGIN;$ORIGIN/numkong")
+        endif ()
+
+        if (DEFINED _USEARCH_NUMKONG_RPATH)
+            set_target_properties(
+                ${TARGET_NAME} PROPERTIES BUILD_RPATH "${_USEARCH_NUMKONG_RPATH}"
+                                          INSTALL_RPATH "${_USEARCH_NUMKONG_RPATH}"
+            )
+        endif ()
     endif ()
 
 endfunction ()
@@ -394,6 +409,19 @@ if (USEARCH_USE_NUMKONG)
 
     if (TARGET nk_shared)
         set_target_properties(nk_shared PROPERTIES ENABLE_EXPORTS ON)
+
+        # Windows has no RPATH equivalent, so the dynamic loader only finds
+        # NumKong reliably when it sits next to the binaries that link it.
+        if (WIN32)
+            set_target_properties(
+                nk_shared
+                PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"
+                           RUNTIME_OUTPUT_DIRECTORY_DEBUG "${CMAKE_BINARY_DIR}"
+                           RUNTIME_OUTPUT_DIRECTORY_RELEASE "${CMAKE_BINARY_DIR}"
+                           RUNTIME_OUTPUT_DIRECTORY_RELWITHDEBINFO "${CMAKE_BINARY_DIR}"
+                           RUNTIME_OUTPUT_DIRECTORY_MINSIZEREL "${CMAKE_BINARY_DIR}"
+            )
+        endif ()
     endif ()
 endif ()
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -484,6 +484,7 @@ Then, on Windows, copy the library to the CSharp project and run the tests:
 ```sh
 mkdir -p ".\csharp\lib\runtimes\win-x64\native"
 cp ".\build_artifacts\libusearch_c.dll" ".\csharp\lib\runtimes\win-x64\native"
+cp ".\build_artifacts\numkong.dll" ".\csharp\lib\runtimes\win-x64\native"
 cd csharp
 dotnet test -c Debug --logger "console;verbosity=detailed"
 dotnet test -c Release
@@ -494,8 +495,10 @@ On Linux, the process is similar:
 ```sh
 mkdir -p "csharp/lib/runtimes/linux-x64/native" # for x86
 cp "build_artifacts/libusearch_c.so" "csharp/lib/runtimes/linux-x64/native" # for x86
+cp "build_artifacts/numkong/libnumkong.so" "csharp/lib/runtimes/linux-x64/native" # for x86
 mkdir -p "csharp/lib/runtimes/linux-arm64/native" # for ARM
 cp "build_artifacts/libusearch_c.so" "csharp/lib/runtimes/linux-arm64/native" # for ARM
+cp "build_artifacts/numkong/libnumkong.so" "csharp/lib/runtimes/linux-arm64/native" # for ARM
 cd csharp
 dotnet test -c Debug --logger "console;verbosity=detailed"
 dotnet test -c Release


### PR DESCRIPTION
### Summary

This updates the C# native build and packaging flow for USearch v2.25, where NumKong is now a separate runtime library instead of being embedded into `libusearch_c`.

Changes include:
- Build Windows C# native artifacts with `USEARCH_USE_NUMKONG=1`.
- Copy `libnumkong.so`, `libnumkong.dylib`, and `numkong.dll` alongside `libusearch_c`.
- Add loader/RPATH handling so `libusearch_c` can find NumKong at runtime.
- Add native runtime asset tests to catch missing bundled dependencies.

### Validation

- Built `usearch_c` locally with NumKong enabled on Windows.
- Confirmed `libusearch_c.dll` depends on `numkong.dll` via `dumpbin`.