### PR TITLE
Make: Build JavaScript Windows x64 prebuilds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -816,9 +816,6 @@ jobs:
         arch: [x64]
         os: [macos-14, ubuntu-24.04, windows-2022]
     runs-on: ${{ matrix.os }}
-    env:
-      CC: gcc
-      CXX: g++
 
     steps:
       - name: Checkout the latest code
@@ -845,7 +842,16 @@ jobs:
         run: |
           npm install --ignore-scripts
       - run: npm run prebuild-single
-        if: matrix.os != 'macos-14'
+        env:
+          CC: gcc
+          CXX: g++
+        if: matrix.os == 'ubuntu-24.04'
+        # Leave CC/CXX unset on Windows. node-gyp builds with MSVC regardless,
+        # but NumKong's ISA probe takes the compiler from $CC while still
+        # passing MSVC flag syntax, so a `gcc` here fails every probe and
+        # silently yields a scalar-only binary with no SIMD kernels.
+      - run: npm run prebuild-single
+        if: matrix.os == 'windows-2022'
       - run: npm run prebuild-darwin-x64+arm64
         env:
           CC: clang

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -813,15 +813,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        arch: [x64, x86]
-        # Windows pre-build is not working
-        # - windows-latest
-        os: [macos-14, ubuntu-24.04]
-        exclude:
-          - arch: x86
-            os: macos-14
-          - arch: x86
-            os: ubuntu-24.04
+        arch: [x64]
+        os: [macos-14, ubuntu-24.04, windows-2022]
     runs-on: ${{ matrix.os }}
     env:
       CC: gcc


### PR DESCRIPTION
This PR enables Windows x64 Node.js prebuilds for the `usearch` npm package.

### The Issue
Currently, the `usearch` npm tarball lacks Windows prebuilds (e.g., `prebuilds/win32-x64/usearch.node`), causing `require("usearch")` to fail on Windows environments. The `package.json` and `javascript/usearch.ts` files are already configured to handle Windows prebuilds, but the `build_javascript` CI job had Windows commented out.

### The Fix
- Added `windows-2022` to the `build_javascript` OS matrix.
- Narrowed the `arch` matrix to `[x64]` and removed the redundant `exclude` block (since `x86` was already excluded for both macOS and Ubuntu).

### Verification
To ensure this works without breaking the release pipeline, a safe fork-only smoke test was run on `windows-2022`. The smoke test confirmed:
1. `npm run prebuild-single` compiles successfully on Windows x64.
2. `npm pack` correctly includes `package/prebuilds/win32-x64/usearch.node` in the generated tarball.
3. A fresh project can install the packed tarball and successfully execute `require('usearch')`.

Smoke test evidence: https://github.com/GraDea/USearch/actions/runs/29040426768