### PR TITLE
Bound file-controlled sizes in view(): levels region and dense vectors span (OOB read on crafted index)

### DIFF
--- a/cpp/test.cpp
+++ b/cpp/test.cpp
@@ -1427,6 +1427,67 @@ void test_load_after_metric_make() {
     std::remove(path);
 }
 
+/**
+ *  @brief  Feeds `view` a truncated index file.
+ *
+ *  The matrix dimensions and the node count come from the file itself, so a short file
+ *  describes a matrix and a level array that reach past the mapping. Both must be rejected
+ *  rather than walked, and a caller-supplied offset past the end must fail the same way.
+ */
+void test_view_of_truncated_file() {
+    std::printf("Testing view of a truncated index file\n");
+
+    using index_t = index_dense_gt<std::int64_t, std::uint32_t>;
+    std::size_t const dimensions = 64;
+    std::size_t const collection = 2048;
+    char const* path = "tmp_truncated.usearch";
+
+    metric_punned_t metric(dimensions, metric_kind_t::l2sq_k, scalar_kind<f32_t>());
+    index_t::state_result_t built = index_t::make(metric);
+    expect(built);
+    expect(built.index.try_reserve(collection));
+    std::vector<float> vector(dimensions);
+    for (std::size_t i = 0; i != collection; ++i) {
+        for (std::size_t d = 0; d != dimensions; ++d)
+            vector[d] = static_cast<float>((i * 31 + d) % 997) / 997.f;
+        expect(built.index.add(static_cast<std::int64_t>(i), vector.data()));
+    }
+    expect(built.index.save(path));
+
+    std::vector<char> prefix;
+    {
+        std::FILE* file = std::fopen(path, "rb");
+        expect(file != nullptr);
+        std::fseek(file, 0, SEEK_END);
+        long const bytes = std::ftell(file);
+        std::fseek(file, 0, SEEK_SET);
+        prefix.resize(static_cast<std::size_t>(bytes) / 8);
+        expect(std::fread(prefix.data(), 1, prefix.size(), file) == prefix.size());
+        std::fclose(file);
+    }
+    {
+        std::FILE* file = std::fopen(path, "wb");
+        expect(file != nullptr);
+        std::fwrite(prefix.data(), 1, prefix.size(), file);
+        std::fclose(file);
+    }
+
+    index_t::state_result_t viewed = index_t::make(metric);
+    expect(viewed);
+    serialization_result_t truncated = viewed.index.view(path);
+    expect(!truncated);
+    truncated.error.release();
+
+    // A caller-supplied offset past the end must fail the same way.
+    index_t::state_result_t offset_viewed = index_t::make(metric);
+    expect(offset_viewed);
+    serialization_result_t beyond = offset_viewed.index.view(memory_mapped_file_t(path), prefix.size() * 4);
+    expect(!beyond);
+    beyond.error.release();
+
+    std::remove(path);
+}
+
 int main(int, char**) {
     install_crash_handlers();
 
@@ -1523,5 +1584,6 @@ int main(int, char**) {
     test_filtered_search();
     test_isolate();
     test_load_after_metric_make();
+    test_view_of_truncated_file();
     return 0;
 }

--- a/include/usearch/index.hpp
+++ b/include/usearch/index.hpp
@@ -3970,6 +3970,10 @@ class index_gt {
                                                  : checked_size_overflow();
         if (!first_offset)
             return result.failed("Index is too large");
+        if (file.size() < first_offset.value) {
+            reset();
+            return result.failed("File is corrupted and can't fit the node levels");
+        }
         offsets[0u] = first_offset.value;
         for (std::size_t i = 1; i < header_size.value; ++i) {
             checked_size_result_t next_offset = checked_add(offsets[i - 1], node_bytes_(levels[i - 1]));

--- a/include/usearch/index_dense.hpp
+++ b/include/usearch/index_dense.hpp
@@ -1383,14 +1383,19 @@ class index_dense_gt {
                 matrix_cols = dimensions[1];
                 offset += sizeof(dimensions);
             }
-            vectors_buffer = {file.data() + offset, static_cast<std::size_t>(matrix_rows * matrix_cols)};
+            // bound the vectors matrix span against the file (overflow-safe; offset <= file.size() holds here)
+            checked_size_result_t vectors_bytes =
+                checked_mul(static_cast<std::size_t>(matrix_rows), static_cast<std::size_t>(matrix_cols));
+            if (!vectors_bytes || file.size() - offset < vectors_bytes.value)
+                return result.failed("File is corrupted: vectors matrix exceeds file size");
+            vectors_buffer = {file.data() + offset, vectors_bytes.value};
             offset += vectors_buffer.size();
         }
 
         // Load metadata and choose the right metric
         {
             index_dense_head_buffer_t buffer;
-            if (file.size() - offset < sizeof(buffer))
+            if (offset > file.size() || file.size() - offset < sizeof(buffer))
                 return result.failed("File is corrupted and lacks a header");
 
             std::memcpy(buffer, file.data() + offset, sizeof(buffer));

--- a/include/usearch/index_dense.hpp
+++ b/include/usearch/index_dense.hpp
@@ -1358,6 +1358,11 @@ class index_dense_gt {
         if (!result)
             return result;
 
+        // `offset` is caller-supplied, so every `file.size() - offset` below would
+        // otherwise underflow into a huge span instead of failing.
+        if (offset > file.size())
+            return result.failed("File is corrupted and lacks matrix dimensions");
+
         // Infer the new index size
         std::uint64_t matrix_rows = 0;
         std::uint64_t matrix_cols = 0;
@@ -1395,7 +1400,7 @@ class index_dense_gt {
         // Load metadata and choose the right metric
         {
             index_dense_head_buffer_t buffer;
-            if (offset > file.size() || file.size() - offset < sizeof(buffer))
+            if (file.size() - offset < sizeof(buffer))
                 return result.failed("File is corrupted and lacks a header");
 
             std::memcpy(buffer, file.data() + offset, sizeof(buffer));


### PR DESCRIPTION
### Summary

`index_gt::view` (and `index_dense::view`) read file-controlled sizes and dereference the memory mapping before bounding them, so a crafted `.usearch` index over-reads the mapping. Two sinks:

1. **Base `view()` levels region** (`index.hpp`): `view` sizes a memory-mapped `levels[]` array from the file's `header.size` and walks it in the offset-precompute loop *before* the `if (file.size() < total_bytes)` check runs. A crafted header declaring more nodes than the file contains reads `levels[]` past the mapping. Fix: reject when the file does not extend to `first_offset` (the end of the levels array) before the loop.

2. **Dense `view()` vectors span** (`index_dense.hpp`): `vectors_buffer = {file.data() + offset, matrix_rows * matrix_cols}` forms a span with no file-size check (and the product can overflow `size_t`), and the following `if (file.size() - offset < sizeof(buffer))` guard is an unsigned subtraction that underflows once `offset` passes `file.size()`. Fix: bound the span with a checked multiply and make the header guard underflow-safe.

### Impact

Memory-mapping a crafted or untrusted `.usearch` index via `Index.view` / `Index.load(..., view=True)` yields an out-of-bounds read (crash / adjacent-memory disclosure). CWE-125.

### Validation

AddressSanitizer, control vs crafted, driving the real `view()` over a buffer-backed mapping: a well-formed index loads cleanly; a crafted one (`header.size` larger than the file / oversized matrix dims) is now rejected with a clear error and no OOB. Found with a structure-aware model/index parser fuzzer.
