### PR TITLE
Fix: Respect Cargo-selected Windows CRT

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -74,7 +74,6 @@ fn build_usearch() -> Result<(), Box<dyn Error>> {
             .flag_if_supported("/fp:fast")
             .flag_if_supported("/W1") // Reduce warnings verbosity
             .flag_if_supported("/EHsc")
-            .flag_if_supported("/MD")
             .flag_if_supported("/permissive-")
             .flag_if_supported("/sdl-")
             .define("_ALLOW_RUNTIME_LIBRARY_MISMATCH", None)


### PR DESCRIPTION
## Summary

Remove explicit `/MD` from Rust build script. `cc` already selects dynamic or static MSVC runtime from Cargo target features; forcing `/MD` overrides `+crt-static` consumers and can mix runtimes across one final binary.

## Validation

- `cargo test -p usearch --no-default-features`: 18 passed
- `cargo clippy -p usearch --no-default-features --all-targets -- -D warnings`
- Diff contains one flag deletion.

## Draft notes

Linux validation covers unchanged Rust/C++ behavior. Windows CI should verify both normal MSVC and `+crt-static` consumers before readiness.