### PR TITLE
Add: Low-bit HNSW candidate generation with exact reranking

### DIFF
--- a/include/usearch/index.hpp
+++ b/include/usearch/index.hpp
@@ -1716,6 +1716,10 @@ struct index_search_config_t {
 
     /// @brief Brute-forces exhaustive search over all entries in the index.
     bool exact = false;
+
+    /// @brief If > 0, performs a 2-stage search, fetching this many candidates using the index metric,
+    /// then exactly re-ranking them using the exact_metric and exact_vectors (if attached).
+    std::size_t exact_candidate_count = 0;
 };
 
 struct index_cluster_config_t {
@@ -2266,6 +2270,7 @@ template <typename distance_at = default_distance_t,              //
           typename tape_allocator_at = dynamic_allocator_at>      //
 class index_gt {
   public:
+    template <typename, typename> friend class index_dense_gt;
     using distance_t = distance_at;
     using vector_key_t = key_at;
     using key_t = vector_key_t;

--- a/include/usearch/index_dense.hpp
+++ b/include/usearch/index_dense.hpp
@@ -10,6 +10,7 @@
 
 #include <usearch/index.hpp>
 #include <usearch/index_plugins.hpp>
+#include <usearch/turboquant.hpp> // TurboQuant rotation + encode
 
 #if defined(USEARCH_DEFINED_CPP17)
 #include <shared_mutex> // `std::shared_mutex`
@@ -477,6 +478,11 @@ class index_dense_gt {
     /// @brief For every managed `compressed_slot_t` stores a pointer to the allocated vector copy.
     mutable vectors_lookup_t vectors_lookup_;
 
+    /// @brief TurboQuant HD³ rotation (shared by all vectors in the index).
+    turboquant_rotation_t tq_rotation_;
+    /// @brief Per-thread scratch buffer for TurboQuant encoding (padded_dim floats).
+    mutable buffer_gt<byte_t, dynamic_allocator_t> tq_scratch_;
+
     using available_threads_allocator_t = aligned_allocator_gt<std::size_t, 64>;
     using available_threads_t = ring_gt<std::size_t, available_threads_allocator_t>;
 
@@ -595,6 +601,8 @@ class index_dense_gt {
 
           vectors_tape_allocator_(std::move(other.vectors_tape_allocator_)), //
           vectors_lookup_(std::move(other.vectors_lookup_)),                 //
+          tq_rotation_(std::move(other.tq_rotation_)),                       //
+          tq_scratch_(std::move(other.tq_scratch_)),                         //
 
           available_threads_(std::move(other.available_threads_)), //
           slot_lookup_(std::move(other.slot_lookup_)),             //
@@ -620,6 +628,8 @@ class index_dense_gt {
 
         std::swap(vectors_tape_allocator_, other.vectors_tape_allocator_);
         std::swap(vectors_lookup_, other.vectors_lookup_);
+        std::swap(tq_rotation_, other.tq_rotation_);
+        std::swap(tq_scratch_, other.tq_scratch_);
 
         std::swap(available_threads_, other.available_threads_);
         std::swap(slot_lookup_, other.slot_lookup_);
@@ -739,6 +749,19 @@ class index_dense_gt {
             if (!new_buffer)
                 return false;
             cast_buffer_ = std::move(new_buffer);
+        }
+        if (metric.is_turboquant()) {
+            if (!tq_rotation_.initialized()) {
+                if (!tq_rotation_.initialize(metric.dimensions()))
+                    return false;
+            }
+            std::size_t scratch_bytes = limits().threads() * tq_rotation_.padded_dim() * sizeof(float);
+            if (scratch_bytes > tq_scratch_.size()) {
+                buffer_gt<byte_t, dynamic_allocator_t> new_scratch(scratch_bytes);
+                if (!new_scratch)
+                    return false;
+                tq_scratch_ = std::move(new_scratch);
+            }
         }
         casts_ = casts_punned_t::make(metric.scalar_kind());
         metric_ = std::move(metric);
@@ -1088,6 +1111,18 @@ class index_dense_gt {
             return false;
         cast_buffer_ = std::move(cast_buffer);
 
+        if (metric_.is_turboquant()) {
+            if (!tq_rotation_.initialized()) {
+                if (!tq_rotation_.initialize(dimensions()))
+                    return false;
+            }
+            std::size_t scratch_bytes = limits.threads() * tq_rotation_.padded_dim() * sizeof(float);
+            buffer_gt<byte_t, dynamic_allocator_t> tq_scratch(scratch_bytes);
+            if (!tq_scratch)
+                return false;
+            tq_scratch_ = std::move(tq_scratch);
+        }
+
         return typed_->reserve(limits);
     }
 
@@ -1421,6 +1456,19 @@ class index_dense_gt {
             cast_buffer_ = cast_buffer_t(cast_buffer_bytes.value);
             if (!cast_buffer_)
                 return result.failed("Failed to allocate memory for the casts");
+            
+            if (metric_.is_turboquant()) {
+                if (!tq_rotation_.initialized()) {
+                    if (!tq_rotation_.initialize(metric_.dimensions()))
+                        return result.failed("Failed to initialize TurboQuant rotation");
+                }
+                std::size_t scratch_bytes = new_limits.threads() * tq_rotation_.padded_dim() * sizeof(float);
+                buffer_gt<byte_t, dynamic_allocator_t> tq_scratch(scratch_bytes);
+                if (!tq_scratch)
+                    return result.failed("Failed to allocate memory for TurboQuant scratch");
+                tq_scratch_ = std::move(tq_scratch);
+            }
+
             casts_ = casts_punned_t::make(head.kind_scalar);
             offset += sizeof(buffer);
         }
@@ -1831,6 +1879,18 @@ class index_dense_gt {
         other.config_ = config_;
         other.cast_buffer_ = std::move(cast_buffer);
         other.casts_ = casts_;
+        
+        if (metric_.is_turboquant()) {
+            if (!other.tq_rotation_.initialize(metric_.dimensions()))
+                return state_result_t{}.failed("Failed to initialize TurboQuant rotation!");
+            
+            std::size_t scratch_bytes = limits().threads() * other.tq_rotation_.padded_dim() * sizeof(float);
+            buffer_gt<byte_t, dynamic_allocator_t> tq_scratch(scratch_bytes);
+            if (!tq_scratch)
+                return state_result_t{}.failed("Failed to allocate memory for TurboQuant scratch!");
+            
+            other.tq_scratch_ = std::move(tq_scratch);
+        }
 
         other.metric_ = metric_;
         other.available_threads_ = std::move(available_threads);
@@ -2169,7 +2229,19 @@ class index_dense_gt {
         byte_t const* vector_data = reinterpret_cast<byte_t const*>(vector);
         {
             byte_t* casted_data = cast_buffer_.data() + metric_.bytes_per_vector() * lock.thread_id;
-            bool casted = cast(vector_data, dimensions(), casted_data);
+            bool casted = false;
+            if (metric_.is_turboquant()) {
+                // TurboQuant encode: float → rotate → quantize → pack.
+                float const* float_input = reinterpret_cast<float const*>(vector);
+                float* scratch = reinterpret_cast<float*>(tq_scratch_.data()) + tq_rotation_.padded_dim() * lock.thread_id;
+                if (metric_.scalar_kind() == scalar_kind_t::tq2_k)
+                    tq_encode_2bit(float_input, tq_rotation_, casted_data, scratch);
+                else
+                    tq_encode_4bit(float_input, tq_rotation_, casted_data, scratch);
+                casted = true;
+            } else {
+                casted = cast(vector_data, dimensions(), casted_data);
+            }
             if (casted)
                 vector_data = casted_data, copy_vector = true;
         }
@@ -2224,10 +2296,22 @@ class index_dense_gt {
         byte_t const* vector_data = reinterpret_cast<byte_t const*>(vector);
         {
             byte_t* casted_data = cast_buffer_.data() + metric_.bytes_per_vector() * lock.thread_id;
-            bool casted = cast(vector_data, dimensions(), casted_data);
+            bool casted = false;
+            if (metric_.is_turboquant()) {
+                float const* float_input = reinterpret_cast<float const*>(vector);
+                float* scratch = reinterpret_cast<float*>(tq_scratch_.data()) + tq_rotation_.padded_dim() * lock.thread_id;
+                if (metric_.scalar_kind() == scalar_kind_t::tq2_k)
+                    tq_encode_2bit(float_input, tq_rotation_, casted_data, scratch);
+                else
+                    tq_encode_4bit(float_input, tq_rotation_, casted_data, scratch);
+                casted = true;
+            } else {
+                casted = cast(vector_data, dimensions(), casted_data);
+            }
             if (casted)
                 vector_data = casted_data;
         }
+
 
         index_search_config_t search_config;
         search_config.thread = lock.thread_id;

--- a/include/usearch/index_dense.hpp
+++ b/include/usearch/index_dense.hpp
@@ -478,6 +478,15 @@ class index_dense_gt {
     /// @brief For every managed `compressed_slot_t` stores a pointer to the allocated vector copy.
     mutable vectors_lookup_t vectors_lookup_;
 
+    using exact_vectors_lookup_allocator_t = aligned_allocator_gt<byte_t const*, 64>;
+    using exact_vectors_lookup_t = buffer_gt<byte_t const*, exact_vectors_lookup_allocator_t>;
+
+    /// @brief Optional F32/High-Precision metric for two-stage reranking.
+    metric_t exact_metric_;
+
+    /// @brief Optional pointers to exact vectors for 2-stage reranking, indexed by slot.
+    mutable exact_vectors_lookup_t exact_vectors_lookup_;
+
     /// @brief TurboQuant HD³ rotation (shared by all vectors in the index).
     turboquant_rotation_t tq_rotation_;
     /// @brief Per-thread scratch buffer for TurboQuant encoding (padded_dim floats).
@@ -601,6 +610,8 @@ class index_dense_gt {
 
           vectors_tape_allocator_(std::move(other.vectors_tape_allocator_)), //
           vectors_lookup_(std::move(other.vectors_lookup_)),                 //
+          exact_metric_(std::move(other.exact_metric_)),                     //
+          exact_vectors_lookup_(std::move(other.exact_vectors_lookup_)),     //
           tq_rotation_(std::move(other.tq_rotation_)),                       //
           tq_scratch_(std::move(other.tq_scratch_)),                         //
 
@@ -628,6 +639,8 @@ class index_dense_gt {
 
         std::swap(vectors_tape_allocator_, other.vectors_tape_allocator_);
         std::swap(vectors_lookup_, other.vectors_lookup_);
+        std::swap(exact_metric_, other.exact_metric_);
+        std::swap(exact_vectors_lookup_, other.exact_vectors_lookup_);
         std::swap(tq_rotation_, other.tq_rotation_);
         std::swap(tq_scratch_, other.tq_scratch_);
 
@@ -768,6 +781,45 @@ class index_dense_gt {
         return true;
     }
 
+    /**
+     *  @brief Attaches an external dataset of exact vectors for 2-stage reranking.
+     *  @param metric The exact metric to use (e.g. F32 inner product).
+     *  @param vectors Base pointer to the exact vectors dataset.
+     *  @param stride Distance between consecutive vectors in the dataset in bytes.
+     *  @param keys Array of vector keys corresponding to the rows of the dataset. If null, assumes key == row index.
+     *  @param count Number of vectors in the dataset.
+     */
+    void view_exact_vectors(metric_t metric, byte_t const* vectors, std::size_t stride, vector_key_t const* keys, std::size_t count) {
+        exact_metric_ = std::move(metric);
+        if (!exact_vectors_lookup_.size() && capacity() > 0) {
+            exact_vectors_lookup_t new_exact_vectors_lookup(capacity());
+            std::memset(new_exact_vectors_lookup.data(), 0, capacity() * sizeof(byte_t const*));
+            exact_vectors_lookup_ = std::move(new_exact_vectors_lookup);
+        } else if (exact_vectors_lookup_.size() > 0) {
+            std::memset(exact_vectors_lookup_.data(), 0, exact_vectors_lookup_.size() * sizeof(byte_t const*));
+        }
+
+        if (keys) {
+            shared_lock_t lock(slot_lookup_mutex_);
+            for (std::size_t i = 0; i < count; ++i) {
+                auto it = slot_lookup_.find(keys[i]);
+                if (it != slot_lookup_.end()) {
+                    compressed_slot_t slot = it->slot;
+                    if (slot != default_free_value<compressed_slot_t>() && slot < exact_vectors_lookup_.size()) {
+                        exact_vectors_lookup_[slot] = vectors + i * stride;
+                    }
+                }
+            }
+        } else {
+            shared_lock_t lock(slot_lookup_mutex_);
+            slot_lookup_.for_each([&](key_and_slot_t const& key_and_slot) {
+                if (key_and_slot.key < count && key_and_slot.slot < exact_vectors_lookup_.size()) {
+                    exact_vectors_lookup_[key_and_slot.slot] = vectors + key_and_slot.key * stride;
+                }
+            });
+        }
+    }
+
     /// @brief Throwing counterpart of @ref try_change_metric.
     void change_metric(metric_t metric) {
         if (!try_change_metric(std::move(metric)))
@@ -904,29 +956,29 @@ class index_dense_gt {
     add_result_t add(vector_key_t key, u8_t const* vector, std::size_t thread = any_thread(), bool copy_vector = true) { return add_(key, vector, thread, copy_vector, casts_.from.u8); }
     add_result_t add(vector_key_t key, b1x8_t const* vector, std::size_t thread = any_thread(), bool copy_vector = true) { return add_(key, vector, thread, copy_vector, casts_.from.b1x8); }
 
-    search_result_t search(f64_t const* vector, std::size_t wanted, std::size_t thread = any_thread(), bool exact = false) const { return search_(vector, wanted, dummy_predicate_t {}, thread, exact, casts_.from.f64); }
-    search_result_t search(f32_t const* vector, std::size_t wanted, std::size_t thread = any_thread(), bool exact = false) const { return search_(vector, wanted, dummy_predicate_t {}, thread, exact, casts_.from.f32); }
-    search_result_t search(bf16_t const* vector, std::size_t wanted, std::size_t thread = any_thread(), bool exact = false) const { return search_(vector, wanted, dummy_predicate_t {}, thread, exact, casts_.from.bf16); }
-    search_result_t search(f16_t const* vector, std::size_t wanted, std::size_t thread = any_thread(), bool exact = false) const { return search_(vector, wanted, dummy_predicate_t {}, thread, exact, casts_.from.f16); }
-    search_result_t search(e5m2_t const* vector, std::size_t wanted, std::size_t thread = any_thread(), bool exact = false) const { return search_(vector, wanted, dummy_predicate_t {}, thread, exact, casts_.from.e5m2); }
-    search_result_t search(e4m3_t const* vector, std::size_t wanted, std::size_t thread = any_thread(), bool exact = false) const { return search_(vector, wanted, dummy_predicate_t {}, thread, exact, casts_.from.e4m3); }
-    search_result_t search(e3m2_t const* vector, std::size_t wanted, std::size_t thread = any_thread(), bool exact = false) const { return search_(vector, wanted, dummy_predicate_t {}, thread, exact, casts_.from.e3m2); }
-    search_result_t search(e2m3_t const* vector, std::size_t wanted, std::size_t thread = any_thread(), bool exact = false) const { return search_(vector, wanted, dummy_predicate_t {}, thread, exact, casts_.from.e2m3); }
-    search_result_t search(i8_t const* vector, std::size_t wanted, std::size_t thread = any_thread(), bool exact = false) const { return search_(vector, wanted, dummy_predicate_t {}, thread, exact, casts_.from.i8); }
-    search_result_t search(u8_t const* vector, std::size_t wanted, std::size_t thread = any_thread(), bool exact = false) const { return search_(vector, wanted, dummy_predicate_t {}, thread, exact, casts_.from.u8); }
-    search_result_t search(b1x8_t const* vector, std::size_t wanted, std::size_t thread = any_thread(), bool exact = false) const { return search_(vector, wanted, dummy_predicate_t {}, thread, exact, casts_.from.b1x8); }
+    search_result_t search(f64_t const* vector, std::size_t wanted, std::size_t thread = any_thread(), std::size_t exact = 0) const { return search_(vector, wanted, dummy_predicate_t {}, thread, exact, casts_.from.f64); }
+    search_result_t search(f32_t const* vector, std::size_t wanted, std::size_t thread = any_thread(), std::size_t exact = 0) const { return search_(vector, wanted, dummy_predicate_t {}, thread, exact, casts_.from.f32); }
+    search_result_t search(bf16_t const* vector, std::size_t wanted, std::size_t thread = any_thread(), std::size_t exact = 0) const { return search_(vector, wanted, dummy_predicate_t {}, thread, exact, casts_.from.bf16); }
+    search_result_t search(f16_t const* vector, std::size_t wanted, std::size_t thread = any_thread(), std::size_t exact = 0) const { return search_(vector, wanted, dummy_predicate_t {}, thread, exact, casts_.from.f16); }
+    search_result_t search(e5m2_t const* vector, std::size_t wanted, std::size_t thread = any_thread(), std::size_t exact = 0) const { return search_(vector, wanted, dummy_predicate_t {}, thread, exact, casts_.from.e5m2); }
+    search_result_t search(e4m3_t const* vector, std::size_t wanted, std::size_t thread = any_thread(), std::size_t exact = 0) const { return search_(vector, wanted, dummy_predicate_t {}, thread, exact, casts_.from.e4m3); }
+    search_result_t search(e3m2_t const* vector, std::size_t wanted, std::size_t thread = any_thread(), std::size_t exact = 0) const { return search_(vector, wanted, dummy_predicate_t {}, thread, exact, casts_.from.e3m2); }
+    search_result_t search(e2m3_t const* vector, std::size_t wanted, std::size_t thread = any_thread(), std::size_t exact = 0) const { return search_(vector, wanted, dummy_predicate_t {}, thread, exact, casts_.from.e2m3); }
+    search_result_t search(i8_t const* vector, std::size_t wanted, std::size_t thread = any_thread(), std::size_t exact = 0) const { return search_(vector, wanted, dummy_predicate_t {}, thread, exact, casts_.from.i8); }
+    search_result_t search(u8_t const* vector, std::size_t wanted, std::size_t thread = any_thread(), std::size_t exact = 0) const { return search_(vector, wanted, dummy_predicate_t {}, thread, exact, casts_.from.u8); }
+    search_result_t search(b1x8_t const* vector, std::size_t wanted, std::size_t thread = any_thread(), std::size_t exact = 0) const { return search_(vector, wanted, dummy_predicate_t {}, thread, exact, casts_.from.b1x8); }
 
-    template <typename predicate_at> search_result_t filtered_search(f64_t const* vector, std::size_t wanted, predicate_at&& predicate, std::size_t thread = any_thread(), bool exact = false) const { return search_(vector, wanted, std::forward<predicate_at>(predicate), thread, exact, casts_.from.f64); }
-    template <typename predicate_at> search_result_t filtered_search(f32_t const* vector, std::size_t wanted, predicate_at&& predicate, std::size_t thread = any_thread(), bool exact = false) const { return search_(vector, wanted, std::forward<predicate_at>(predicate), thread, exact, casts_.from.f32); }
-    template <typename predicate_at> search_result_t filtered_search(bf16_t const* vector, std::size_t wanted, predicate_at&& predicate, std::size_t thread = any_thread(), bool exact = false) const { return search_(vector, wanted, std::forward<predicate_at>(predicate), thread, exact, casts_.from.bf16); }
-    template <typename predicate_at> search_result_t filtered_search(f16_t const* vector, std::size_t wanted, predicate_at&& predicate, std::size_t thread = any_thread(), bool exact = false) const { return search_(vector, wanted, std::forward<predicate_at>(predicate), thread, exact, casts_.from.f16); }
-    template <typename predicate_at> search_result_t filtered_search(e5m2_t const* vector, std::size_t wanted, predicate_at&& predicate, std::size_t thread = any_thread(), bool exact = false) const { return search_(vector, wanted, std::forward<predicate_at>(predicate), thread, exact, casts_.from.e5m2); }
-    template <typename predicate_at> search_result_t filtered_search(e4m3_t const* vector, std::size_t wanted, predicate_at&& predicate, std::size_t thread = any_thread(), bool exact = false) const { return search_(vector, wanted, std::forward<predicate_at>(predicate), thread, exact, casts_.from.e4m3); }
-    template <typename predicate_at> search_result_t filtered_search(e3m2_t const* vector, std::size_t wanted, predicate_at&& predicate, std::size_t thread = any_thread(), bool exact = false) const { return search_(vector, wanted, std::forward<predicate_at>(predicate), thread, exact, casts_.from.e3m2); }
-    template <typename predicate_at> search_result_t filtered_search(e2m3_t const* vector, std::size_t wanted, predicate_at&& predicate, std::size_t thread = any_thread(), bool exact = false) const { return search_(vector, wanted, std::forward<predicate_at>(predicate), thread, exact, casts_.from.e2m3); }
-    template <typename predicate_at> search_result_t filtered_search(i8_t const* vector, std::size_t wanted, predicate_at&& predicate, std::size_t thread = any_thread(), bool exact = false) const { return search_(vector, wanted, std::forward<predicate_at>(predicate), thread, exact, casts_.from.i8); }
-    template <typename predicate_at> search_result_t filtered_search(u8_t const* vector, std::size_t wanted, predicate_at&& predicate, std::size_t thread = any_thread(), bool exact = false) const { return search_(vector, wanted, std::forward<predicate_at>(predicate), thread, exact, casts_.from.u8); }
-    template <typename predicate_at> search_result_t filtered_search(b1x8_t const* vector, std::size_t wanted, predicate_at&& predicate, std::size_t thread = any_thread(), bool exact = false) const { return search_(vector, wanted, std::forward<predicate_at>(predicate), thread, exact, casts_.from.b1x8); }
+    template <typename predicate_at> search_result_t filtered_search(f64_t const* vector, std::size_t wanted, predicate_at&& predicate, std::size_t thread = any_thread(), std::size_t exact = 0) const { return search_(vector, wanted, std::forward<predicate_at>(predicate), thread, exact, casts_.from.f64); }
+    template <typename predicate_at> search_result_t filtered_search(f32_t const* vector, std::size_t wanted, predicate_at&& predicate, std::size_t thread = any_thread(), std::size_t exact = 0) const { return search_(vector, wanted, std::forward<predicate_at>(predicate), thread, exact, casts_.from.f32); }
+    template <typename predicate_at> search_result_t filtered_search(bf16_t const* vector, std::size_t wanted, predicate_at&& predicate, std::size_t thread = any_thread(), std::size_t exact = 0) const { return search_(vector, wanted, std::forward<predicate_at>(predicate), thread, exact, casts_.from.bf16); }
+    template <typename predicate_at> search_result_t filtered_search(f16_t const* vector, std::size_t wanted, predicate_at&& predicate, std::size_t thread = any_thread(), std::size_t exact = 0) const { return search_(vector, wanted, std::forward<predicate_at>(predicate), thread, exact, casts_.from.f16); }
+    template <typename predicate_at> search_result_t filtered_search(e5m2_t const* vector, std::size_t wanted, predicate_at&& predicate, std::size_t thread = any_thread(), std::size_t exact = 0) const { return search_(vector, wanted, std::forward<predicate_at>(predicate), thread, exact, casts_.from.e5m2); }
+    template <typename predicate_at> search_result_t filtered_search(e4m3_t const* vector, std::size_t wanted, predicate_at&& predicate, std::size_t thread = any_thread(), std::size_t exact = 0) const { return search_(vector, wanted, std::forward<predicate_at>(predicate), thread, exact, casts_.from.e4m3); }
+    template <typename predicate_at> search_result_t filtered_search(e3m2_t const* vector, std::size_t wanted, predicate_at&& predicate, std::size_t thread = any_thread(), std::size_t exact = 0) const { return search_(vector, wanted, std::forward<predicate_at>(predicate), thread, exact, casts_.from.e3m2); }
+    template <typename predicate_at> search_result_t filtered_search(e2m3_t const* vector, std::size_t wanted, predicate_at&& predicate, std::size_t thread = any_thread(), std::size_t exact = 0) const { return search_(vector, wanted, std::forward<predicate_at>(predicate), thread, exact, casts_.from.e2m3); }
+    template <typename predicate_at> search_result_t filtered_search(i8_t const* vector, std::size_t wanted, predicate_at&& predicate, std::size_t thread = any_thread(), std::size_t exact = 0) const { return search_(vector, wanted, std::forward<predicate_at>(predicate), thread, exact, casts_.from.i8); }
+    template <typename predicate_at> search_result_t filtered_search(u8_t const* vector, std::size_t wanted, predicate_at&& predicate, std::size_t thread = any_thread(), std::size_t exact = 0) const { return search_(vector, wanted, std::forward<predicate_at>(predicate), thread, exact, casts_.from.u8); }
+    template <typename predicate_at> search_result_t filtered_search(b1x8_t const* vector, std::size_t wanted, predicate_at&& predicate, std::size_t thread = any_thread(), std::size_t exact = 0) const { return search_(vector, wanted, std::forward<predicate_at>(predicate), thread, exact, casts_.from.b1x8); }
 
     std::size_t get(vector_key_t key, f64_t* vector, std::size_t vectors_count = 1) const { return get_(key, vector, vectors_count, casts_.to.f64); }
     std::size_t get(vector_key_t key, f32_t* vector, std::size_t vectors_count = 1) const { return get_(key, vector, vectors_count, casts_.to.f32); }
@@ -1092,6 +1144,17 @@ class index_dense_gt {
                 std::memcpy(new_vectors_lookup.data(), vectors_lookup_.data(),
                             vectors_lookup_.size() * sizeof(byte_t*));
             vectors_lookup_ = std::move(new_vectors_lookup);
+        }
+
+        if (exact_vectors_lookup_.size() > 0 && limits.members != exact_vectors_lookup_.size()) {
+            exact_vectors_lookup_t new_exact_vectors_lookup(limits.members);
+            if (!new_exact_vectors_lookup)
+                return false;
+            std::memset(new_exact_vectors_lookup.data(), 0, limits.members * sizeof(byte_t const*));
+            if (exact_vectors_lookup_.size() > 0)
+                std::memcpy(new_exact_vectors_lookup.data(), exact_vectors_lookup_.data(),
+                            exact_vectors_lookup_.size() * sizeof(byte_t const*));
+            exact_vectors_lookup_ = std::move(new_exact_vectors_lookup);
         }
 
         // During reserve, no insertions may be happening, so we can safely overwrite the whole collection.
@@ -1456,7 +1519,7 @@ class index_dense_gt {
             cast_buffer_ = cast_buffer_t(cast_buffer_bytes.value);
             if (!cast_buffer_)
                 return result.failed("Failed to allocate memory for the casts");
-            
+
             if (metric_.is_turboquant()) {
                 if (!tq_rotation_.initialized()) {
                     if (!tq_rotation_.initialize(metric_.dimensions()))
@@ -1854,6 +1917,82 @@ class index_dense_gt {
     }
 
     /**
+     *  @brief Creates a copy of the index but re-encodes the vector storage to a new scalar type.
+     *  @param new_scalar The new scalar kind to re-encode the vectors into (e.g. tq4_k).
+     *  @return A new ::index_dense_gt instance sharing the same graph but with re-encoded vectors.
+     */
+    copy_result_t repack(scalar_kind_t new_scalar) const {
+        copy_result_t result = fork();
+        if (!result) return result;
+
+        index_dense_gt& copy = result.index;
+
+        // Setup new metric and casts
+        copy.metric_ = metric_punned_t(metric_.dimensions(), metric_.metric_kind(), new_scalar);
+        copy.casts_ = casts_punned_t::make(new_scalar);
+
+        // If the new scalar is TQ, we must initialize its rotation matrix!
+        if (copy.metric_.is_turboquant()) {
+            if (!copy.tq_rotation_.initialize(copy.metric_.dimensions()))
+                return result.failed("Failed to initialize TurboQuant rotation for repacked index!");
+
+            std::size_t scratch_bytes = limits().threads() * copy.tq_rotation_.padded_dim() * sizeof(float);
+            buffer_gt<byte_t, dynamic_allocator_t> tq_scratch(scratch_bytes);
+            if (!tq_scratch)
+                return result.failed("Failed to allocate memory for TurboQuant scratch!");
+            copy.tq_scratch_ = std::move(tq_scratch);
+        }
+
+        auto typed_result = typed_->copy({});
+        if (!typed_result) return result.failed(std::move(typed_result.error));
+
+        if (!copy.free_keys_.reserve(free_keys_.size())) return result.failed("Out of memory!");
+        for (std::size_t i = 0; i != free_keys_.size(); ++i) copy.free_keys_.push(free_keys_[i]);
+
+        copy.vectors_lookup_ = vectors_lookup_t(vectors_lookup_.size());
+        if (!copy.vectors_lookup_) return result.failed("Out of memory!");
+
+        std::size_t slots_count = typed_result.index.size();
+        for (std::size_t slot = 0; slot != slots_count; ++slot) {
+            copy.vectors_lookup_[slot] = copy.vectors_tape_allocator_.allocate(copy.metric_.bytes_per_vector());
+        }
+        if (std::count(copy.vectors_lookup_.begin(), copy.vectors_lookup_.begin() + slots_count, nullptr))
+            return result.failed("Out of memory!");
+
+        if (exact_vectors_lookup_.size() > 0) {
+            copy.exact_metric_ = exact_metric_;
+            copy.exact_vectors_lookup_ = exact_vectors_lookup_t(exact_vectors_lookup_.size());
+            if (!copy.exact_vectors_lookup_) return result.failed("Out of memory!");
+            std::memcpy(copy.exact_vectors_lookup_.data(), exact_vectors_lookup_.data(), exact_vectors_lookup_.size() * sizeof(byte_t const*));
+        }
+
+        // Now, we must copy AND quantize the vectors.
+        // For this specific experiment, we assume current metric is F32 and new is TQ4/TQ2.
+        if (metric_.scalar_kind() == scalar_kind_t::f32_k && copy.metric_.is_turboquant()) {
+            std::size_t dim = metric_.dimensions();
+            float* scratch = (float*)std::malloc(copy.tq_rotation_.padded_dim() * sizeof(float));
+            if (!scratch) return result.failed("Out of memory!");
+
+            for (std::size_t slot = 0; slot != slots_count; ++slot) {
+                float const* f32_vec = (float const*)vectors_lookup_[slot];
+                byte_t* tq_vec = (byte_t*)copy.vectors_lookup_[slot];
+
+                if (new_scalar == scalar_kind_t::tq4_k)
+                    tq_encode_4bit(f32_vec, copy.tq_rotation_, tq_vec, scratch);
+                else if (new_scalar == scalar_kind_t::tq2_k)
+                    tq_encode_2bit(f32_vec, copy.tq_rotation_, tq_vec, scratch);
+            }
+            std::free(scratch);
+        } else {
+            return result.failed("repack() currently only supports F32 -> TQ4/TQ2 conversions!");
+        }
+
+        copy.slot_lookup_ = slot_lookup_;
+        *copy.typed_ = std::move(typed_result.index);
+        return result;
+    }
+
+    /**
      *  @brief Copies the ::index_dense_gt model @b without any data.
      *  @return A similarly configured ::index_dense_gt instance.
      */
@@ -1879,16 +2018,16 @@ class index_dense_gt {
         other.config_ = config_;
         other.cast_buffer_ = std::move(cast_buffer);
         other.casts_ = casts_;
-        
+
         if (metric_.is_turboquant()) {
             if (!other.tq_rotation_.initialize(metric_.dimensions()))
                 return state_result_t{}.failed("Failed to initialize TurboQuant rotation!");
-            
+
             std::size_t scratch_bytes = limits().threads() * other.tq_rotation_.padded_dim() * sizeof(float);
             buffer_gt<byte_t, dynamic_allocator_t> tq_scratch(scratch_bytes);
             if (!tq_scratch)
                 return state_result_t{}.failed("Failed to allocate memory for TurboQuant scratch!");
-            
+
             other.tq_scratch_ = std::move(tq_scratch);
         }
 
@@ -2287,7 +2426,7 @@ class index_dense_gt {
 
     template <typename scalar_at, typename predicate_at>
     search_result_t search_(scalar_at const* vector, std::size_t wanted, predicate_at&& predicate, std::size_t thread,
-                            bool exact, cast_punned_t const& cast) const {
+                            std::size_t exact, cast_punned_t const& cast) const {
 
         // Cast the vector, if needed for compatibility with `metric_`
         thread_lock_t lock = thread_lock_(thread);
@@ -2316,20 +2455,59 @@ class index_dense_gt {
         index_search_config_t search_config;
         search_config.thread = lock.thread_id;
         search_config.expansion = config_.expansion_search;
-        search_config.exact = exact;
+        search_config.exact = (exact == 1);
+        search_config.exact_candidate_count = exact;
+
+        std::size_t candidates_to_fetch = (exact > wanted && exact_vectors_lookup_.size() > 0 && exact_metric_) ? exact : wanted;
+
+        auto rerank = [&](typename index_t::search_result_t& typed_result) {
+            if (exact > wanted && exact_vectors_lookup_.size() > 0 && exact_metric_) {
+                auto context_ptr = typed_->context_or_null_(lock.thread_id);
+                if (context_ptr && context_ptr->top_candidates.size() > 0) {
+                    auto& top = context_ptr->top_candidates;
+                    std::size_t extracted_count = top.size();
+                    usearch::buffer_gt<typename index_t::candidate_t, typename index_t::candidates_allocator_t> rerank_buffer(extracted_count);
+                    if (rerank_buffer) {
+                        for (std::size_t i = 0; i < extracted_count; ++i) {
+                            rerank_buffer[i] = top.pop();
+                        }
+                        top.clear();
+
+                        // Use the ORIGINAL exact query vector, not the TQ4 compressed vector_data
+                        byte_t const* query_exact = reinterpret_cast<byte_t const*>(vector);
+
+                        for (std::size_t i = 0; i < extracted_count; ++i) {
+                            auto& candidate = rerank_buffer[i];
+                            if (candidate.slot != default_free_value<compressed_slot_t>() && candidate.slot < exact_vectors_lookup_.size()) {
+                                byte_t const* exact_vec = exact_vectors_lookup_[candidate.slot];
+                                if (exact_vec) {
+                                    candidate.distance = exact_metric_(query_exact, exact_vec);
+                                } else {
+                                    candidate.distance = infinite_distance();
+                                }
+                            }
+                            top.insert(std::move(candidate), wanted);
+                        }
+                        typed_result.count = top.size();
+                    }
+                }
+            }
+        };
 
         vector_key_t free_key_copy = free_key_;
         if (std::is_same<typename std::decay<predicate_at>::type, dummy_predicate_t>::value) {
             auto allow = [free_key_copy](member_cref_t const& member) noexcept {
                 return (vector_key_t)member.key != free_key_copy;
             };
-            auto typed_result = typed_->search(vector_data, wanted, metric_proxy_t{*this}, search_config, allow);
+            auto typed_result = typed_->search(vector_data, candidates_to_fetch, metric_proxy_t{*this}, search_config, allow);
+            rerank(typed_result);
             return search_result_t{std::move(typed_result), std::move(lock)};
         } else {
             auto allow = [free_key_copy, &predicate](member_cref_t const& member) noexcept {
                 return (vector_key_t)member.key != free_key_copy && predicate(member.key);
             };
-            auto typed_result = typed_->search(vector_data, wanted, metric_proxy_t{*this}, search_config, allow);
+            auto typed_result = typed_->search(vector_data, candidates_to_fetch, metric_proxy_t{*this}, search_config, allow);
+            rerank(typed_result);
             return search_result_t{std::move(typed_result), std::move(lock)};
         }
     }

--- a/include/usearch/index_plugins.hpp
+++ b/include/usearch/index_plugins.hpp
@@ -9,6 +9,7 @@
 #include <thread>  // `std::thread`
 
 #include <usearch/index.hpp> // `expected_gt` and macros
+#include <usearch/turboquant_metric.hpp> // TurboQuant distance functions
 
 #if defined(USEARCH_DEFINED_LINUX)
 #include <sys/auxv.h> // `getauxval()`
@@ -161,6 +162,9 @@ enum class scalar_kind_t : std::uint8_t {
     i32_k = 21,
     i16_k = 22,
     i8_k = 23,
+    // TurboQuant compressed (data-oblivious, training-free):
+    tq2_k = 30, ///< TurboQuant 2-bit per dimension (normalized vectors)
+    tq4_k = 31, ///< TurboQuant 4-bit per dimension (normalized vectors)
 };
 
 /**
@@ -268,6 +272,8 @@ inline std::size_t bits_per_scalar(scalar_kind_t scalar_kind) noexcept {
     case scalar_kind_t::e4m3_k: return 8;
     case scalar_kind_t::e2m3_k: return 8;
     case scalar_kind_t::e3m2_k: return 8;
+    case scalar_kind_t::tq2_k: return 2;
+    case scalar_kind_t::tq4_k: return 4;
     default: return 0;
     }
 }
@@ -297,6 +303,8 @@ inline std::size_t bits_per_scalar_word(scalar_kind_t scalar_kind) noexcept {
     case scalar_kind_t::e4m3_k: return 8;
     case scalar_kind_t::e2m3_k: return 8;
     case scalar_kind_t::e3m2_k: return 8;
+    case scalar_kind_t::tq2_k: return 8;
+    case scalar_kind_t::tq4_k: return 8;
     default: return 0;
     }
 }
@@ -325,6 +333,8 @@ inline char const* scalar_kind_name(scalar_kind_t scalar_kind) noexcept {
     case scalar_kind_t::e4m3_k: return "e4m3";
     case scalar_kind_t::e2m3_k: return "e2m3";
     case scalar_kind_t::e3m2_k: return "e3m2";
+    case scalar_kind_t::tq2_k: return "tq2";
+    case scalar_kind_t::tq4_k: return "tq4";
     default: return "";
     }
 }
@@ -2918,11 +2928,17 @@ class metric_punned_t {
         metric_punned_t metric;
         metric.metric_routed_ = &metric_punned_t::invoke_array_array_third;
         metric.metric_ptr_ = 0;
-        metric.metric_third_arg_ =
-            scalar_kind == scalar_kind_t::b1x8_k ? divide_round_up<CHAR_BIT>(dimensions) : dimensions;
         metric.dimensions_ = dimensions;
         metric.metric_kind_ = metric_kind;
         metric.scalar_kind_ = scalar_kind;
+        // For TurboQuant, the third argument is the padded dimension (power of 2).
+        // For b1x8, it's the number of bytes.  For everything else, it's just dimensions.
+        if (scalar_kind == scalar_kind_t::tq2_k || scalar_kind == scalar_kind_t::tq4_k)
+            metric.metric_third_arg_ = metric.storage_dimensions_();
+        else if (scalar_kind == scalar_kind_t::b1x8_k)
+            metric.metric_third_arg_ = divide_round_up<CHAR_BIT>(dimensions);
+        else
+            metric.metric_third_arg_ = dimensions;
 
         if (!metric.configure_with_numkong())
             metric.configure_with_autovec();
@@ -3009,7 +3025,12 @@ class metric_punned_t {
     }
 
     inline std::size_t bytes_per_vector() const noexcept {
-        return divide_round_up<CHAR_BIT>(dimensions_ * bits_per_scalar(scalar_kind_));
+        return divide_round_up<CHAR_BIT>(storage_dimensions_() * bits_per_scalar(scalar_kind_));
+    }
+
+    /// @brief  True if this metric operates on TurboQuant-compressed vectors.
+    inline bool is_turboquant() const noexcept {
+        return scalar_kind_ == scalar_kind_t::tq2_k || scalar_kind_ == scalar_kind_t::tq4_k;
     }
 
     inline std::size_t scalar_words() const noexcept {
@@ -3095,6 +3116,20 @@ class metric_punned_t {
 #else
     bool configure_with_numkong() noexcept { return false; }
 #endif
+    /// @brief  For TurboQuant types, storage dimensions are padded to the next power of 2 (WHT requirement).
+    inline std::size_t storage_dimensions_() const noexcept {
+        if (scalar_kind_ == scalar_kind_t::tq2_k || scalar_kind_ == scalar_kind_t::tq4_k) {
+            // Pad to next power of 2.
+            std::size_t n = dimensions_;
+            if (n == 0) return 1;
+            n--;
+            n |= n >> 1; n |= n >> 2; n |= n >> 4;
+            n |= n >> 8; n |= n >> 16; n |= n >> 32;
+            return n + 1;
+        }
+        return dimensions_;
+    }
+
     result_t invoke_array_array_third(uptr_t a, uptr_t b) const noexcept {
         auto function_pointer = (metric_array_array_size_t)(metric_ptr_);
         result_t result = function_pointer(a, b, metric_third_arg_);
@@ -3119,6 +3154,8 @@ class metric_punned_t {
             case scalar_kind_t::e2m3_k: metric_ptr_ = (uptr_t)&equidimensional_<metric_ip_gt<e2m3_t, f32_t>>; break;
             case scalar_kind_t::i8_k: metric_ptr_ = (uptr_t)&equidimensional_<metric_ip_gt<i8_t, f32_t>>; break;
             case scalar_kind_t::u8_k: metric_ptr_ = (uptr_t)&equidimensional_<metric_ip_gt<u8_t, f32_t>>; break;
+            case scalar_kind_t::tq2_k: metric_ptr_ = (uptr_t)&tq_metric_ip_2bit; break;
+            case scalar_kind_t::tq4_k: metric_ptr_ = (uptr_t)&tq_metric_ip_4bit; break;
             default: metric_ptr_ = 0; break;
             }
             break;
@@ -3135,6 +3172,8 @@ class metric_punned_t {
             case scalar_kind_t::e2m3_k: metric_ptr_ = (uptr_t)&equidimensional_<metric_cos_gt<e2m3_t, f32_t>>; break;
             case scalar_kind_t::i8_k: metric_ptr_ = (uptr_t)&equidimensional_<metric_cos_i8_t>; break;
             case scalar_kind_t::u8_k: metric_ptr_ = (uptr_t)&equidimensional_<metric_cos_u8_t>; break;
+            case scalar_kind_t::tq2_k: metric_ptr_ = (uptr_t)&tq_metric_cos_2bit; break;
+            case scalar_kind_t::tq4_k: metric_ptr_ = (uptr_t)&tq_metric_cos_4bit; break;
             default: metric_ptr_ = 0; break;
             }
             break;
@@ -3151,6 +3190,8 @@ class metric_punned_t {
             case scalar_kind_t::e2m3_k: metric_ptr_ = (uptr_t)&equidimensional_<metric_l2sq_gt<e2m3_t, f32_t>>; break;
             case scalar_kind_t::i8_k: metric_ptr_ = (uptr_t)&equidimensional_<metric_l2sq_i8_t>; break;
             case scalar_kind_t::u8_k: metric_ptr_ = (uptr_t)&equidimensional_<metric_l2sq_u8_t>; break;
+            case scalar_kind_t::tq2_k: metric_ptr_ = (uptr_t)&tq_metric_l2sq_2bit; break;
+            case scalar_kind_t::tq4_k: metric_ptr_ = (uptr_t)&tq_metric_l2sq_4bit; break;
             default: metric_ptr_ = 0; break;
             }
             break;

--- a/include/usearch/turboquant.hpp
+++ b/include/usearch/turboquant.hpp
@@ -1,0 +1,23 @@
+/**
+ *  @file       turboquant.hpp
+ *  @brief      Umbrella header for TurboQuant integration in USearch.
+ *
+ *  TurboQuant is a data-oblivious vector quantization algorithm that compresses
+ *  dense high-dimensional vectors to 2–4 bits per coordinate with near-optimal
+ *  distortion.  It requires no training and supports online insertions.
+ *
+ *  References:
+ *      Zandieh, Daliri, Hadian, Mirrokni.
+ *      "TurboQuant: Online Vector Quantization with Near-optimal Distortion Rate"
+ *      arXiv:2504.19874, ICLR 2026.
+ *
+ *  Architecture:
+ *      turboquant_rotation.hpp  — HD³ (randomized Hadamard) rotation
+ *      turboquant_codec.hpp     — Lloyd-Max codebooks + encode/decode
+ *      turboquant_metric.hpp    — Distance functions on compressed vectors
+ */
+#pragma once
+
+#include <usearch/turboquant_rotation.hpp>
+#include <usearch/turboquant_codec.hpp>
+#include <usearch/turboquant_metric.hpp>

--- a/include/usearch/turboquant_codec.hpp
+++ b/include/usearch/turboquant_codec.hpp
@@ -1,0 +1,236 @@
+/**
+ *  @file       turboquant_codec.hpp
+ *  @brief      TurboQuant encoder: Lloyd-Max codebooks + bit-packing.
+ *
+ *  Contains pre-computed optimal scalar quantizer codebooks for the standard
+ *  Gaussian N(0,1) distribution (which the HD³-rotated coordinates approximate
+ *  in high dimensions), plus encoding and decoding routines.
+ *
+ *  Encoding is on the CRITICAL PATH (called during add/search).
+ *  Decoding is OFF the critical path (tests/export only).
+ */
+#pragma once
+#include <usearch/turboquant_rotation.hpp>
+
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+
+namespace unum {
+namespace usearch {
+
+// ===================================================================
+// Pre-computed Lloyd-Max codebooks for N(0,1)
+// ===================================================================
+//
+// After HD³ rotation, each coordinate of a unit vector follows
+// approximately N(0, 1/d).  Scaling by sqrt(d) yields N(0,1).
+//
+// The centroids and decision boundaries below are the optimal
+// Lloyd-Max solution for N(0,1).  At encode time we scale by
+// sqrt(padded_dim); at decode time we scale back by 1/sqrt(padded_dim).
+// ===================================================================
+
+/// @brief  2-bit codebook (4 centroids) for N(0,1).
+struct tq_codebook_2bit {
+    static constexpr unsigned bit_width = 2;
+    static constexpr unsigned num_centroids = 4;
+
+    /// Centroids in ascending order.
+    static constexpr float centroids[4] = {-1.5104f, -0.4528f, 0.4528f, 1.5104f};
+
+    /// Decision boundaries (num_centroids - 1).
+    static constexpr float boundaries[3] = {-0.9816f, 0.0f, 0.9816f};
+
+    /// Symmetric product LUT: lut[i][j] = centroids[i] * centroids[j].
+    /// Used for symmetric compressed × compressed inner product.
+    static constexpr float product_lut[4][4] = {
+        {2.2813f, 0.6839f, -0.6839f, -2.2813f}, //
+        {0.6839f, 0.2050f, -0.2050f, -0.6839f}, //
+        {-0.6839f, -0.2050f, 0.2050f, 0.6839f}, //
+        {-2.2813f, -0.6839f, 0.6839f, 2.2813f}, //
+    };
+};
+
+/// @brief  4-bit codebook (16 centroids) for N(0,1).
+struct tq_codebook_4bit {
+    static constexpr unsigned bit_width = 4;
+    static constexpr unsigned num_centroids = 16;
+
+    /// Centroids in ascending order.
+    static constexpr float centroids[16] = {
+        -2.7326f, -2.0691f, -1.6180f, -1.2562f, //
+        -0.9424f, -0.6568f, -0.3881f, -0.1284f, //
+        0.1284f, 0.3881f, 0.6568f, 0.9424f,      //
+        1.2562f, 1.6180f, 2.0691f, 2.7326f,       //
+    };
+
+    /// Decision boundaries (num_centroids - 1).
+    static constexpr float boundaries[15] = {
+        -2.4009f, -1.8436f, -1.4371f, -1.0993f, //
+        -0.7996f, -0.5224f, -0.2582f, 0.0f,      //
+        0.2582f, 0.5224f, 0.7996f, 1.0993f,       //
+        1.4371f, 1.8436f, 2.4009f,                 //
+    };
+};
+
+// ===================================================================
+// Compressed vector size calculation
+// ===================================================================
+
+/**
+ *  @brief  Size in bytes of a TurboQuant-compressed vector.
+ *  @param  padded_dim  Padded dimension (power of 2).
+ *  @param  bit_width   Bits per coordinate (2 or 4).
+ */
+inline std::size_t tq_compressed_bytes(std::size_t padded_dim, unsigned bit_width) noexcept {
+    return (padded_dim * bit_width + 7) / 8;
+}
+
+// ===================================================================
+// 2-bit encode / decode
+// ===================================================================
+
+/**
+ *  @brief  Find the nearest centroid index for a scaled coordinate.
+ *          Branchless version using the 3 decision boundaries.
+ */
+inline std::uint8_t tq_quantize_2bit(float scaled) noexcept {
+    // boundaries = {-0.9816, 0.0, 0.9816}
+    // Result: 0 if scaled < -0.9816
+    //         1 if -0.9816 <= scaled < 0.0
+    //         2 if 0.0 <= scaled < 0.9816
+    //         3 if scaled >= 0.9816
+    std::uint8_t idx = 0;
+    idx += (scaled >= tq_codebook_2bit::boundaries[0]) ? 1 : 0;
+    idx += (scaled >= tq_codebook_2bit::boundaries[1]) ? 1 : 0;
+    idx += (scaled >= tq_codebook_2bit::boundaries[2]) ? 1 : 0;
+    return idx;
+}
+
+/**
+ *  @brief  Encode a float vector to 2-bit TurboQuant compressed form.
+ *
+ *  Assumes the input is a UNIT VECTOR (||vector|| ≈ 1).
+ *
+ *  @param  vector    Input float vector of length @p original_dim.
+ *  @param  rotation  HD³ rotation (must be initialized for @p original_dim).
+ *  @param  output    Output buffer of length tq_compressed_bytes(padded_dim, 2).
+ *  @param  scratch   Temporary float buffer of length rotation.padded_dim().
+ *                    Caller must allocate this (avoids per-call allocation).
+ */
+inline void tq_encode_2bit(float const* vector, turboquant_rotation_t const& rotation, //
+                           byte_t* output, float* scratch) noexcept {
+    std::size_t const pd = rotation.padded_dim();
+    float const sqrt_d = std::sqrt(static_cast<float>(pd));
+
+    // Step 1: Rotate.
+    rotation.forward(vector, scratch);
+
+    // Step 2: Quantize each coordinate and pack 4 indices per byte.
+    std::size_t byte_idx = 0;
+    std::size_t bit_pos = 0;
+    byte_t current_byte = 0;
+
+    for (std::size_t i = 0; i < pd; ++i) {
+        float scaled = scratch[i] * sqrt_d;
+        std::uint8_t idx = tq_quantize_2bit(scaled);
+
+        current_byte |= static_cast<byte_t>(idx << bit_pos);
+        bit_pos += 2;
+
+        if (bit_pos == 8) {
+            output[byte_idx++] = current_byte;
+            current_byte = 0;
+            bit_pos = 0;
+        }
+    }
+    // Flush remaining bits (shouldn't happen if pd is power of 2 and >= 4).
+    if (bit_pos > 0)
+        output[byte_idx] = current_byte;
+}
+
+/**
+ *  @brief  Find the nearest centroid index for a 4-bit quantization.
+ *          Linear scan over 15 boundaries (fast for 16 entries).
+ */
+inline std::uint8_t tq_quantize_4bit(float scaled) noexcept {
+    std::uint8_t idx = 0;
+    for (unsigned b = 0; b < 15; ++b)
+        idx += (scaled >= tq_codebook_4bit::boundaries[b]) ? 1 : 0;
+    return idx;
+}
+
+/**
+ *  @brief  Encode a float vector to 4-bit TurboQuant compressed form.
+ *
+ *  Assumes the input is a UNIT VECTOR (||vector|| ≈ 1).
+ */
+inline void tq_encode_4bit(float const* vector, turboquant_rotation_t const& rotation, //
+                           byte_t* output, float* scratch) noexcept {
+    std::size_t const pd = rotation.padded_dim();
+    float const sqrt_d = std::sqrt(static_cast<float>(pd));
+
+    // Step 1: Rotate.
+    rotation.forward(vector, scratch);
+
+    // Step 2: Quantize each coordinate and pack 2 indices per byte.
+    for (std::size_t i = 0; i < pd; i += 2) {
+        float scaled_lo = scratch[i] * sqrt_d;
+        float scaled_hi = (i + 1 < pd) ? scratch[i + 1] * sqrt_d : 0.0f;
+
+        std::uint8_t idx_lo = tq_quantize_4bit(scaled_lo);
+        std::uint8_t idx_hi = tq_quantize_4bit(scaled_hi);
+
+        output[i / 2] = static_cast<byte_t>(idx_lo | (idx_hi << 4));
+    }
+}
+
+// ===================================================================
+// Decode (for testing / export only — NOT on the critical path)
+// ===================================================================
+
+/**
+ *  @brief  Decode a 2-bit compressed vector back to float.
+ *          This is NOT used during search; only for testing roundtrip quality.
+ */
+inline void tq_decode_2bit(byte_t const* compressed, turboquant_rotation_t const& rotation, //
+                           float* output) noexcept {
+    std::size_t const pd = rotation.padded_dim();
+    float const inv_sqrt_d = 1.0f / std::sqrt(static_cast<float>(pd));
+
+    // Reconstruct rotated vector from codebook.
+    std::vector<float> rotated(pd);
+    for (std::size_t i = 0; i < pd; ++i) {
+        std::size_t byte_idx = i / 4;
+        std::size_t bit_pos = (i % 4) * 2;
+        std::uint8_t idx = (compressed[byte_idx] >> bit_pos) & 0x03;
+        rotated[i] = tq_codebook_2bit::centroids[idx] * inv_sqrt_d;
+    }
+
+    // Inverse rotate.
+    rotation.inverse(rotated.data(), output);
+}
+
+/**
+ *  @brief  Decode a 4-bit compressed vector back to float.
+ *          This is NOT used during search; only for testing roundtrip quality.
+ */
+inline void tq_decode_4bit(byte_t const* compressed, turboquant_rotation_t const& rotation, //
+                           float* output) noexcept {
+    std::size_t const pd = rotation.padded_dim();
+    float const inv_sqrt_d = 1.0f / std::sqrt(static_cast<float>(pd));
+
+    std::vector<float> rotated(pd);
+    for (std::size_t i = 0; i < pd; ++i) {
+        std::size_t byte_idx = i / 2;
+        std::uint8_t idx = (i % 2 == 0) ? (compressed[byte_idx] & 0x0F) : ((compressed[byte_idx] >> 4) & 0x0F);
+        rotated[i] = tq_codebook_4bit::centroids[idx] * inv_sqrt_d;
+    }
+
+    rotation.inverse(rotated.data(), output);
+}
+
+} // namespace usearch
+} // namespace unum

--- a/include/usearch/turboquant_metric.hpp
+++ b/include/usearch/turboquant_metric.hpp
@@ -1,0 +1,152 @@
+/**
+ *  @file       turboquant_metric.hpp
+ *  @brief      Distance functions for TurboQuant-compressed vectors.
+ *
+ *  Provides symmetric inner-product computation on pairs of compressed
+ *  vectors (both sides quantized).  The query rotation is performed once
+ *  per search call and cached; the metric itself only operates on packed
+ *  index arrays.
+ *
+ *  Design:
+ *  - Symmetric: compressed × compressed  (used by HNSW for both add & search)
+ *  - LUT-based: a 4×4 (2-bit) or 16×16 (4-bit) product table maps every
+ *    pair of centroid indices to the product centroid[i]×centroid[j].
+ *  - The total IP = (1/padded_dim) × Σ LUT[idx_a[i]][idx_b[i]].
+ *  - Distance is returned as  1 − IP  (lower = more similar), matching
+ *    USearch's convention for ip_k / cos_k metrics.
+ */
+#pragma once
+#include <usearch/turboquant_codec.hpp>
+
+#include <cstddef>
+#include <cstdint>
+
+namespace unum {
+namespace usearch {
+
+// ===================================================================
+// 2-bit symmetric inner product  (compressed × compressed)
+// ===================================================================
+
+/**
+ *  @brief  Compute distance = 1 − IP between two 2-bit compressed vectors.
+ *
+ *  @param  a            First compressed vector.
+ *  @param  b            Second compressed vector.
+ *  @param  padded_dim   Padded dimension (power of 2).
+ *  @return  1.0 − estimated_inner_product.
+ *
+ *  Uses the pre-computed product LUT from tq_codebook_2bit.
+ *  Each byte contains 4 × 2-bit indices, processed together.
+ */
+inline float tq_distance_ip_2bit(byte_t const* a, byte_t const* b, std::size_t padded_dim) noexcept {
+    float const inv_d = 1.0f / static_cast<float>(padded_dim);
+    float sum = 0.0f;
+
+    std::size_t const num_bytes = padded_dim / 4; // 4 indices per byte at 2 bits
+    for (std::size_t byte_i = 0; byte_i < num_bytes; ++byte_i) {
+        std::uint8_t const ba = static_cast<std::uint8_t>(a[byte_i]);
+        std::uint8_t const bb = static_cast<std::uint8_t>(b[byte_i]);
+
+        // Unpack 4 pairs of 2-bit indices and accumulate products.
+        sum += tq_codebook_2bit::product_lut[(ba >> 0) & 3][(bb >> 0) & 3];
+        sum += tq_codebook_2bit::product_lut[(ba >> 2) & 3][(bb >> 2) & 3];
+        sum += tq_codebook_2bit::product_lut[(ba >> 4) & 3][(bb >> 4) & 3];
+        sum += tq_codebook_2bit::product_lut[(ba >> 6) & 3][(bb >> 6) & 3];
+    }
+
+    float ip = sum * inv_d;
+    return 1.0f - ip;
+}
+
+/**
+ *  @brief  Compute distance = 1 − IP between two 2-bit compressed vectors.
+ *          Version with the third argument being the padded dimension,
+ *          matching metric_punned_t's array_array_size signature.
+ */
+inline float tq_metric_ip_2bit(std::size_t a_ptr, std::size_t b_ptr, std::size_t padded_dim) noexcept {
+    return tq_distance_ip_2bit(reinterpret_cast<byte_t const*>(a_ptr), //
+                               reinterpret_cast<byte_t const*>(b_ptr), padded_dim);
+}
+
+// ===================================================================
+// 4-bit symmetric inner product  (compressed × compressed)
+// ===================================================================
+
+/**
+ *  @brief  Compute distance = 1 − IP between two 4-bit compressed vectors.
+ *
+ *  Each byte contains 2 × 4-bit indices (lo nibble + hi nibble).
+ *  Uses direct centroid multiplication (16 × 16 = 256 products).
+ *  The product is computed on the fly rather than from a static LUT
+ *  because 256 floats (1 KB) wouldn't be cache-friendly.
+ *
+ *  TODO: SIMD fast path with vpshufb for 4-bit → centroid lookup.
+ */
+inline float tq_distance_ip_4bit(byte_t const* a, byte_t const* b, std::size_t padded_dim) noexcept {
+    float const inv_d = 1.0f / static_cast<float>(padded_dim);
+    float sum = 0.0f;
+
+    std::size_t const num_bytes = padded_dim / 2; // 2 indices per byte at 4 bits
+    float const* cb = tq_codebook_4bit::centroids;
+
+    for (std::size_t byte_i = 0; byte_i < num_bytes; ++byte_i) {
+        std::uint8_t const ba = static_cast<std::uint8_t>(a[byte_i]);
+        std::uint8_t const bb = static_cast<std::uint8_t>(b[byte_i]);
+
+        // Low nibble.
+        sum += cb[ba & 0x0F] * cb[bb & 0x0F];
+        // High nibble.
+        sum += cb[(ba >> 4) & 0x0F] * cb[(bb >> 4) & 0x0F];
+    }
+
+    float ip = sum * inv_d;
+    return 1.0f - ip;
+}
+
+/**
+ *  @brief  metric_punned_t-compatible wrapper for 4-bit IP distance.
+ */
+inline float tq_metric_ip_4bit(std::size_t a_ptr, std::size_t b_ptr, std::size_t padded_dim) noexcept {
+    return tq_distance_ip_4bit(reinterpret_cast<byte_t const*>(a_ptr), //
+                               reinterpret_cast<byte_t const*>(b_ptr), padded_dim);
+}
+
+// ===================================================================
+// L2 squared from IP  (for normalized vectors:  L2² = 2(1 − IP))
+// ===================================================================
+
+inline float tq_distance_l2sq_2bit(byte_t const* a, byte_t const* b, std::size_t padded_dim) noexcept {
+    float const ip_dist = tq_distance_ip_2bit(a, b, padded_dim); // 1 - IP
+    return 2.0f * ip_dist;                                        // 2(1 - IP)
+}
+
+inline float tq_metric_l2sq_2bit(std::size_t a_ptr, std::size_t b_ptr, std::size_t pd) noexcept {
+    return tq_distance_l2sq_2bit(reinterpret_cast<byte_t const*>(a_ptr), //
+                                 reinterpret_cast<byte_t const*>(b_ptr), pd);
+}
+
+inline float tq_distance_l2sq_4bit(byte_t const* a, byte_t const* b, std::size_t padded_dim) noexcept {
+    float const ip_dist = tq_distance_ip_4bit(a, b, padded_dim);
+    return 2.0f * ip_dist;
+}
+
+inline float tq_metric_l2sq_4bit(std::size_t a_ptr, std::size_t b_ptr, std::size_t pd) noexcept {
+    return tq_distance_l2sq_4bit(reinterpret_cast<byte_t const*>(a_ptr), //
+                                 reinterpret_cast<byte_t const*>(b_ptr), pd);
+}
+
+// ===================================================================
+// Cosine distance  (for normalized vectors: cos_dist = 1 − IP = ip_dist)
+// ===================================================================
+
+inline float tq_metric_cos_2bit(std::size_t a_ptr, std::size_t b_ptr, std::size_t pd) noexcept {
+    return tq_metric_ip_2bit(a_ptr, b_ptr, pd);
+}
+
+inline float tq_metric_cos_4bit(std::size_t a_ptr, std::size_t b_ptr, std::size_t pd) noexcept {
+    return tq_metric_ip_4bit(a_ptr, b_ptr, pd);
+}
+
+} // namespace usearch
+} // namespace unum

--- a/include/usearch/turboquant_rotation.hpp
+++ b/include/usearch/turboquant_rotation.hpp
@@ -1,0 +1,214 @@
+/**
+ *  @file       turboquant_rotation.hpp
+ *  @brief      HD³ (randomized Hadamard) rotation for TurboQuant.
+ *
+ *  Implements the fast pseudo-random rotation used by TurboQuant to induce
+ *  a near-Gaussian distribution on each coordinate.  Three rounds of
+ *  (diagonal-sign-flip + normalized Walsh-Hadamard Transform) give a
+ *  rotation quality close to a full random orthogonal matrix while running
+ *  in O(d log d) time and requiring only O(d) extra memory (the signs).
+ *
+ *  The transform is fully deterministic given a 64-bit seed, so the same
+ *  seed reproduces the same rotation on any platform.
+ */
+#pragma once
+#include <usearch/index.hpp> // buffer_gt, byte_t, expected_gt
+
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+
+namespace unum {
+namespace usearch {
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Returns the smallest power of two >= n (n > 0).
+inline std::size_t tq_next_power_of_2(std::size_t n) noexcept {
+    if (n == 0) return 1;
+    n--;
+    n |= n >> 1;
+    n |= n >> 2;
+    n |= n >> 4;
+    n |= n >> 8;
+    n |= n >> 16;
+    n |= n >> 32;
+    return n + 1;
+}
+
+// ---------------------------------------------------------------------------
+// Fast Walsh-Hadamard Transform (in-place, unnormalized)
+// ---------------------------------------------------------------------------
+
+/**
+ *  @brief  In-place unnormalized WHT (butterfly formulation).
+ *          Result is H_unnorm * data, where H_unnorm has ±1 entries.
+ *          Caller must divide by sqrt(n) afterwards for the orthonormal version.
+ *  @param  data   Array of length @p n (must be a power of 2).
+ *  @param  n      Length of @p data.
+ */
+inline void tq_fwht_inplace(float* data, std::size_t n) noexcept {
+    for (std::size_t len = 1; len < n; len <<= 1) {
+        for (std::size_t i = 0; i < n; i += (len << 1)) {
+            for (std::size_t j = 0; j < len; ++j) {
+                float const u = data[i + j];
+                float const v = data[i + j + len];
+                data[i + j] = u + v;
+                data[i + j + len] = u - v;
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// SplitMix64-based deterministic sign generator
+// ---------------------------------------------------------------------------
+
+inline std::uint64_t tq_splitmix64(std::uint64_t& state) noexcept {
+    std::uint64_t z = (state += 0x9E3779B97F4A7C15ULL);
+    z = (z ^ (z >> 30)) * 0xBF58476D1CE4E5B9ULL;
+    z = (z ^ (z >> 27)) * 0x94D049BB133111EBULL;
+    return z ^ (z >> 31);
+}
+
+// ---------------------------------------------------------------------------
+// HD³ Rotation
+// ---------------------------------------------------------------------------
+
+/**
+ *  @brief  Randomized Hadamard rotation (HD³).
+ *
+ *  Forward transform:  y = H · D₂ · H · D₁ · H · D₀ · x
+ *  (applied as:  D₀ → WHT → D₁ → WHT → D₂ → WHT)
+ *
+ *  Inverse transform:  x = D₀ · H · D₁ · H · D₂ · H · y
+ *  (applied as:  WHT → D₂ → WHT → D₁ → WHT → D₀)
+ *
+ *  where H is the normalized Hadamard (WHT / √n) and Dₖ are diagonal ±1.
+ */
+class turboquant_rotation_t {
+  public:
+    static constexpr std::size_t rounds_k = 3;
+
+    std::size_t original_dim_ = 0;
+    std::size_t padded_dim_ = 0;
+    std::uint64_t seed_ = 0;
+
+    /// 3 × padded_dim_ sign bytes (+1 or −1).
+    buffer_gt<std::int8_t> signs_;
+
+    /// 1 / √padded_dim_  (pre-computed).
+    float inv_sqrt_n_ = 0;
+
+  public:
+    turboquant_rotation_t() noexcept = default;
+    turboquant_rotation_t(turboquant_rotation_t&&) noexcept = default;
+    turboquant_rotation_t& operator=(turboquant_rotation_t&&) noexcept = default;
+
+    /**
+     *  @brief  Initializes the rotation for a given vector dimensionality.
+     *  @param  dim   Original (unpadded) dimensionality.
+     *  @param  seed  64-bit seed for reproducibility.
+     *  @return True on success, false on allocation failure.
+     */
+    bool initialize(std::size_t dim, std::uint64_t seed = 42) noexcept {
+        original_dim_ = dim;
+        padded_dim_ = tq_next_power_of_2(dim);
+        seed_ = seed;
+        inv_sqrt_n_ = 1.0f / std::sqrt(static_cast<float>(padded_dim_));
+
+        signs_ = buffer_gt<std::int8_t>(rounds_k * padded_dim_);
+        if (!signs_)
+            return false;
+
+        // Generate deterministic ±1 signs from the seed.
+        std::uint64_t state = seed;
+        for (std::size_t i = 0; i < rounds_k * padded_dim_; ++i)
+            signs_[i] = (tq_splitmix64(state) & 1) ? std::int8_t(1) : std::int8_t(-1);
+
+        return true;
+    }
+
+    /**
+     *  @brief  Forward HD³ rotation.
+     *
+     *  @param  input   Source vector of length original_dim().
+     *  @param  output  Destination buffer of length padded_dim().
+     *                  May alias @p input only if padded_dim() == original_dim().
+     *
+     *  The caller is responsible for allocating @p output.
+     */
+    void forward(float const* input, float* output) const noexcept {
+        // Copy + zero-pad.
+        std::memcpy(output, input, original_dim_ * sizeof(float));
+        if (padded_dim_ > original_dim_)
+            std::memset(output + original_dim_, 0, (padded_dim_ - original_dim_) * sizeof(float));
+
+        // 3 rounds: Dₖ then normalized WHT.
+        for (std::size_t r = 0; r < rounds_k; ++r) {
+            std::int8_t const* s = signs_.data() + r * padded_dim_;
+            // Diagonal sign flip.
+            for (std::size_t i = 0; i < padded_dim_; ++i)
+                output[i] *= s[i];
+            // Unnormalized WHT then scale.
+            tq_fwht_inplace(output, padded_dim_);
+            for (std::size_t i = 0; i < padded_dim_; ++i)
+                output[i] *= inv_sqrt_n_;
+        }
+    }
+
+    /**
+     *  @brief  Inverse HD³ rotation.
+     *
+     *  @param  input   Source vector of length padded_dim().
+     *  @param  output  Destination buffer of length original_dim().
+     *
+     *  Only the first original_dim() components of the inverse are written.
+     */
+    void inverse(float const* input, float* output) const noexcept {
+        // We need a full padded_dim_ buffer for the computation.
+        // Use the caller-provided output as scratch if large enough, otherwise
+        // fall back to a local buffer.  Since padded_dim_ >= original_dim_,
+        // output is always large enough if we work carefully.
+        //
+        // In practice, callers wanting the inverse should allocate padded_dim_
+        // floats.  For safety we accept original_dim_ and use a stack buffer
+        // only for small dimensions (≤ 4096).  Larger cases require a
+        // padded_dim_-sized output.
+        //
+        // For simplicity here, we do a small dynamic allocation via alloca-style
+        // if needed.  In the test-only path this is acceptable.
+        //
+        // Because inverse is NOT on the critical path (per design), a simple
+        // heap allocation is fine.
+        std::vector<float> buf(padded_dim_);
+        float* tmp = buf.data();
+        std::memcpy(tmp, input, padded_dim_ * sizeof(float));
+
+        // Inverse: WHT → D₂ → WHT → D₁ → WHT → D₀
+        for (std::size_t r = rounds_k; r-- > 0;) {
+            tq_fwht_inplace(tmp, padded_dim_);
+            for (std::size_t i = 0; i < padded_dim_; ++i)
+                tmp[i] *= inv_sqrt_n_;
+            std::int8_t const* s = signs_.data() + r * padded_dim_;
+            for (std::size_t i = 0; i < padded_dim_; ++i)
+                tmp[i] *= s[i];
+        }
+
+        // Copy the first original_dim_ elements.
+        std::memcpy(output, tmp, original_dim_ * sizeof(float));
+    }
+
+    // -- Accessors ----------------------------------------------------------
+
+    std::size_t original_dim() const noexcept { return original_dim_; }
+    std::size_t padded_dim() const noexcept { return padded_dim_; }
+    std::uint64_t seed() const noexcept { return seed_; }
+    bool initialized() const noexcept { return signs_.size() > 0; }
+};
+
+} // namespace usearch
+} // namespace unum

--- a/python/lib.cpp
+++ b/python/lib.cpp
@@ -97,6 +97,7 @@ struct dense_indexes_py_t {
     void merge(std::shared_ptr<dense_index_py_t> shard) { shards_.push_back(shard); }
     std::size_t bytes_per_vector() const noexcept { return shards_.empty() ? 0 : shards_[0]->bytes_per_vector(); }
     std::size_t scalar_words() const noexcept { return shards_.empty() ? 0 : shards_[0]->scalar_words(); }
+    std::size_t dimensions() const noexcept { return shards_.empty() ? 0 : shards_[0]->dimensions(); }
     index_limits_t limits() const noexcept { return {size(), std::numeric_limits<std::size_t>::max()}; }
 
     void merge_paths(std::vector<std::string> const& paths, bool view = true, std::size_t threads = 0) {
@@ -272,7 +273,8 @@ static void add_many_to_index(                            //
     Py_ssize_t keys_count = keys_info.shape[0];
     Py_ssize_t vectors_count = vectors_info.shape[0];
     Py_ssize_t vectors_dimensions = vectors_info.shape[1];
-    if (vectors_dimensions != static_cast<Py_ssize_t>(index.scalar_words()))
+    if (vectors_dimensions != static_cast<Py_ssize_t>(index.scalar_words()) &&
+        vectors_dimensions != static_cast<Py_ssize_t>(index.dimensions()))
         throw std::invalid_argument("The number of vector dimensions doesn't match!");
 
     if (keys_count != vectors_count)
@@ -489,7 +491,8 @@ static py::tuple search_many_in_index( //
 
     Py_ssize_t vectors_count = vectors_info.shape[0];
     Py_ssize_t vectors_dimensions = vectors_info.shape[1];
-    if (vectors_dimensions != static_cast<Py_ssize_t>(index.scalar_words()))
+    if (vectors_dimensions != static_cast<Py_ssize_t>(index.scalar_words()) &&
+        vectors_dimensions != static_cast<Py_ssize_t>(index.dimensions()))
         throw std::invalid_argument("The number of vector dimensions doesn't match!");
     if (vectors_info.strides[1] != static_cast<Py_ssize_t>(vectors_info.itemsize))
         throw std::invalid_argument("Matrix rows must be contiguous, try `ascontiguousarray`.");
@@ -1184,7 +1187,9 @@ PYBIND11_MODULE(compiled, m, py::mod_gil_not_used()) {
         .value("U16", scalar_kind_t::u16_k)
         .value("I64", scalar_kind_t::i64_k)
         .value("I32", scalar_kind_t::i32_k)
-        .value("I16", scalar_kind_t::i16_k);
+        .value("I16", scalar_kind_t::i16_k)
+        .value("TQ2", scalar_kind_t::tq2_k)
+        .value("TQ4", scalar_kind_t::tq4_k);
 
     m.def("index_dense_metadata_from_path", [](std::string const& path) -> py::dict {
         index_dense_metadata_result_t meta = index_dense_metadata_from_path(path.c_str());

--- a/python/lib.cpp
+++ b/python/lib.cpp
@@ -311,7 +311,7 @@ static void add_many_to_index(                            //
 template <typename scalar_at>
 static void search_typed(                                   //
     dense_index_py_t& index, py::buffer_info& vectors_info, //
-    std::size_t wanted, bool exact, std::size_t threads,    //
+    std::size_t wanted, std::size_t exact, std::size_t threads,    //
     py::array_t<dense_key_t>& keys_py, py::array_t<distance_t>& distances_py, py::array_t<Py_ssize_t>& counts_py,
     std::atomic<std::size_t>& stats_visited_members, std::atomic<std::size_t>& stats_computed_distances,
     progress_func_t const& progress) {
@@ -377,7 +377,7 @@ static void search_typed(                                   //
 template <typename scalar_at>
 static void search_typed(                                       //
     dense_indexes_py_t& indexes, py::buffer_info& vectors_info, //
-    std::size_t wanted, bool exact, std::size_t threads,        //
+    std::size_t wanted, std::size_t exact, std::size_t threads,        //
     py::array_t<dense_key_t>& keys_py, py::array_t<distance_t>& distances_py, py::array_t<Py_ssize_t>& counts_py,
     std::atomic<std::size_t>& stats_visited_members, std::atomic<std::size_t>& stats_computed_distances,
     progress_func_t const& progress) {
@@ -476,7 +476,7 @@ static void search_typed(                                       //
  */
 template <typename index_at>
 static py::tuple search_many_in_index( //
-    index_at& index, py::buffer vectors, std::size_t wanted, bool exact, std::size_t threads,
+    index_at& index, py::buffer vectors, std::size_t wanted, std::size_t exact, std::size_t threads,
     progress_func_t const& progress, scalar_kind_t scalar_kind = scalar_kind_t::unknown_k) {
 
     if (wanted == 0)
@@ -923,6 +923,14 @@ static dense_index_py_t copy_index(dense_index_py_t const& index, bool force_cop
     return std::move(result.index);
 }
 
+static dense_index_py_t repack_index(dense_index_py_t const& index, scalar_kind_t new_scalar) {
+
+    using copy_result_t = typename dense_index_py_t::copy_result_t;
+    copy_result_t result = index.repack(new_scalar);
+    forward_error(result);
+    return std::move(result.index);
+}
+
 static void compact_index(dense_index_py_t& index, std::size_t threads, progress_func_t const& progress) {
 
     if (!threads)
@@ -933,6 +941,46 @@ static void compact_index(dense_index_py_t& index, std::size_t threads, progress
     if (!index.try_reserve(index_limits_t(index.size(), threads)))
         throw std::invalid_argument("Out of memory!");
     index.compact(executor_default_t{threads}, progress_t{progress});
+}
+
+template <typename index_at>
+static void view_exact_vectors(index_at& index, py::buffer vectors, std::optional<py::buffer> keys, scalar_kind_t scalar_kind = scalar_kind_t::unknown_k) {
+    py::buffer_info vectors_info = vectors.request();
+    if (vectors_info.ndim != 2)
+        throw std::invalid_argument("Expects a matrix of exact vectors!");
+
+    Py_ssize_t vectors_count = vectors_info.shape[0];
+    Py_ssize_t vectors_dimensions = vectors_info.shape[1];
+    if (vectors_info.strides[1] != static_cast<Py_ssize_t>(vectors_info.itemsize))
+        throw std::invalid_argument("Matrix rows must be contiguous, try `ascontiguousarray`.");
+
+    if (scalar_kind == scalar_kind_t::unknown_k) {
+        if (vectors_info.format == py::format_descriptor<float>::format())
+            scalar_kind = scalar_kind_t::f32_k;
+        else if (vectors_info.format == py::format_descriptor<double>::format())
+            scalar_kind = scalar_kind_t::f64_k;
+        else if (vectors_info.format == py::format_descriptor<std::int8_t>::format() || vectors_info.format == "b")
+            scalar_kind = scalar_kind_t::i8_k;
+        else if (vectors_info.format == "e")
+            scalar_kind = scalar_kind_t::f16_k;
+        else
+            throw std::invalid_argument("Unrecognized exact vector type. Try explicitly passing `dtype`.");
+    }
+    metric_kind_t metric_kind = index.metric().metric_kind();
+    metric_punned_t exact_metric(vectors_dimensions, metric_kind, scalar_kind);
+
+    dense_key_t const* keys_data = nullptr;
+    if (keys.has_value()) {
+        py::buffer_info keys_info = keys->request();
+        if (keys_info.itemsize != sizeof(dense_key_t))
+            throw std::invalid_argument("Incompatible key type!");
+        if (keys_info.shape[0] != vectors_count)
+            throw std::invalid_argument("Number of keys and exact vectors must match!");
+        keys_data = reinterpret_cast<dense_key_t const*>(keys_info.ptr);
+    }
+
+    std::size_t stride = vectors_info.strides[0];
+    index.view_exact_vectors(std::move(exact_metric), reinterpret_cast<byte_t const*>(vectors_info.ptr), stride, keys_data, vectors_count);
 }
 
 static py::dict index_metadata(index_dense_metadata_result_t const& meta) {
@@ -1279,10 +1327,17 @@ PYBIND11_MODULE(compiled, m, py::mod_gil_not_used()) {
         "search_many", &search_many_in_index<dense_index_py_t>, //
         py::arg("queries"),                                     //
         py::arg("count") = 10,                                  //
-        py::arg("exact") = false,                               //
+        py::arg("exact") = 0,                               //
         py::arg("threads") = 0,                                 //
         py::arg("progress") = nullptr,                          //
         py::arg("dtype") = scalar_kind_t::unknown_k             //
+    );
+
+    i.def(
+        "view_exact_vectors", &view_exact_vectors<dense_index_py_t>, //
+        py::arg("vectors"),                                         //
+        py::arg("keys") = py::none(),                                //
+        py::arg("dtype") = scalar_kind_t::unknown_k                  //
     );
 
     i.def(                                                     //
@@ -1515,6 +1570,7 @@ PYBIND11_MODULE(compiled, m, py::mod_gil_not_used()) {
     i.def("reset", &reset_index<dense_index_py_t>);
     i.def("clear", &clear_index<dense_index_py_t>);
     i.def("copy", &copy_index, py::kw_only(), py::arg("copy") = true);
+    i.def("repack", &repack_index, py::arg("new_scalar"));
     i.def("compact", &compact_index, py::arg("threads"), py::arg("progress") = nullptr);
     i.def("join", &join_index, py::arg("other"), py::arg("max_proposals") = 0, py::arg("exact") = false,
           py::arg("progress") = nullptr);

--- a/python/usearch/index.py
+++ b/python/usearch/index.py
@@ -1212,6 +1212,29 @@ class Index:
         result._compiled = self._compiled.copy()
         return result
 
+    def repack(self, dtype: Union[str, ScalarKind]) -> "Index":
+        """Creates a copy of the index but re-encodes the vector storage to a new scalar type.
+
+        :param dtype: The new scalar type to re-encode the vectors into (e.g., 'tq4', 'tq2').
+        :type dtype: Union[str, ScalarKind]
+        :return: A new instance of the Index class with the same graph but re-encoded vectors.
+        :rtype: Index
+        """
+        from usearch.index import _normalize_dtype
+        dtype = _normalize_dtype(dtype)
+
+        result = Index(
+            ndim=self.ndim,
+            metric=self.metric,
+            dtype=dtype,
+            connectivity=self.connectivity,
+            expansion_add=self.expansion_add,
+            expansion_search=self.expansion_search,
+        )
+        result._compiled = self._compiled.repack(dtype)
+        return result
+
+
     def join(
         self,
         other: Index,
@@ -1422,6 +1445,22 @@ class Index:
             - `allocated_bytes` (int): Memory allocated for the level.
         """
         return self._compiled.level_stats(level)
+
+    def view_exact_vectors(self, vectors: VectorOrVectorsLike, keys: KeyOrKeysLike | None = None, dtype: DTypeLike | None = None):
+        """Supplies the exact uncompressed vectors for 2-stage reranking search.
+
+        :param vectors: The dataset containing uncompressed/exact vectors.
+        :type vectors: VectorOrVectorsLike
+        :param keys: Optional keys matching the vectors to their corresponding index slots.
+        :type keys: Optional[KeyOrKeysLike]
+        :param dtype: The numeric type of the provided vectors (defaults to the index type).
+        :type dtype: Optional[DTypeLike]
+        """
+        if dtype is None:
+            dtype = ScalarKind.Unknown
+        elif isinstance(dtype, str):
+            dtype = ScalarKind[dtype.upper()]
+        return self._compiled.view_exact_vectors(vectors, keys, dtype)
 
     @property
     def specs(self) -> dict[str, str | int | bool]:

--- a/python/usearch/index.py
+++ b/python/usearch/index.py
@@ -138,6 +138,8 @@ def _normalize_dtype(
         "bfloat16": ScalarKind.BF16,
         "float16": ScalarKind.F16,
         "int8": ScalarKind.I8,
+        "tq2": getattr(ScalarKind, "TQ2", None),
+        "tq4": getattr(ScalarKind, "TQ4", None),
         np.float64: ScalarKind.F64,
         np.float32: ScalarKind.F32,
         np.float16: ScalarKind.F16,


### PR DESCRIPTION
## Summary

This PR adds a native two-stage retrieval path for USearch:

1. Use a low-bit compressed HNSW index to generate candidates.
2. Rerank only those candidates with exact Float32 SIMD distances.

The concrete low-bit codec added here is **TurboQuant**, exposed as **TQ4** and **TQ2** scalar kinds. The main contribution, however, is the retrieval architecture: compressed search does not need to produce the final ordering by itself. It only needs to preserve the right candidates well enough for a small exact reranker to restore the final order.

An interesting observation is TQ2. Pure TQ2 loses substantial direct recall, but it still brings many of the correct neighbors into the candidate pool. With exact reranking, it recovers Float32-level Recall@10 in the tested workloads while reducing the measured index RAM by roughly 7x-8x versus Float32.

## Motivation

The initial engineering path was to integrate TurboQuant and then improve quantized search quality. During validation, the important failure mode turned out to be different:

- TQ4 and TQ2 often found the correct candidates.
- The compressed metric frequently ordered those candidates incorrectly.
- Exact reranking over a small candidate set fixed most of the loss.

That changes the optimization target. For HNSW, the compressed representation does not need to be a perfect final metric. It needs to be a compact, fast candidate generator.

This PR therefore emphasizes reranking as the quality-recovery mechanism and uses TurboQuant, especially TQ2, as the current low-bit candidate-generation layer.

## What's included

### Native two-stage exact reranking

Adds an optional exact reranking stage for compressed indexes. Users can attach the original exact vectors:

```python
index.view_exact_vectors(dataset)

matches = index.search(
    queries,
    count=10,
    exact=40,
)
```

When `exact` is greater than `count`, USearch fetches that many compressed HNSW candidates, rescoring them against the attached exact vectors, and returns the final top `count` results.

The pipeline is:

```text
Float32 query
  -> low-bit query encoding
  -> compressed HNSW candidate generation
  -> exact Float32 SIMD rescoring
  -> partial sort
  -> final top-k
```

### Native TurboQuant scalar types

Adds two scalar kinds:

- `ScalarKind.TQ4`
- `ScalarKind.TQ2`

Both are integrated into the existing metric and dispatch plumbing:

- vector encoding on add/search,
- compressed-vector distance metrics,
- scalar metadata and byte-size accounting,
- Python dtype normalization and bindings.

### TurboQuant encoding and metrics

The implementation adds:

- deterministic HD3 randomized Hadamard rotation,
- Lloyd-Max codebooks for 2-bit and 4-bit quantization,
- packed 2-bit and 4-bit vector storage,
- compressed inner-product, cosine, and L2-squared metric dispatch.

The current implementation assumes normalized vectors for the intended cosine/IP use case.

### Graph repacking

Adds:

```python
compressed = index.repack("tq4")
compressed = index.repack("tq2")
```

This creates a new index with the same graph topology and metadata while re-encoding Float32 vector storage into TurboQuant. It is useful for comparing whether quality loss comes from graph topology or from compressed-distance ordering.

### Python API additions

```python
ScalarKind.TQ4
ScalarKind.TQ2

Index.repack(dtype)
Index.view_exact_vectors(vectors, keys=None, dtype=None)
Index.search(..., exact=N)
```

## Implementation notes

Several integration issues were resolved while wiring this into the native index:

- TurboQuant rotation and scratch-buffer initialization during metric changes and forks.
- MSVC allocator compatibility for compressed vector storage.
- Python dimension validation for asymmetric exact-vector workflows.
- Exact-vector lookup by slot/key.
- Exact metric propagation for reranking.
- Candidate handling for two-stage search.
- Python bindings for `repack()` and `view_exact_vectors()`.

## Benchmarks

Benchmarks were run on real embedding datasets, without synthetic vector generation.

Datasets:

- OpenAI `text-embedding-3-large`, 50k vectors, 1536 dimensions.
- Cohere embeddings, 50k vectors, 1024 dimensions.
- OpenAI DBpedia, 1M vectors, 1536 dimensions.

Configuration:

- normalized vectors,
- cosine similarity,
- HNSW,
- Recall@10 against exact Float32 ground truth,
- 1000 query vectors for the 50k benchmarks.

### Why this is unlikely to be a single-dataset artifact

The same pattern appears across different embedding distributions and scales:

- OpenAI 1536d embeddings at 50k vectors.
- Cohere 1024d embeddings at 50k vectors.
- OpenAI DBpedia 1536d embeddings at 1M vectors.

The absolute recall numbers differ by dataset, but the shape of the result is stable:

- Pure TQ2 loses substantially more direct recall than pure TQ4.
- Increasing `exact` from 20 to 40 recovers a large fraction of the lost quality.
- Increasing `efSearch` improves the candidate set, as expected for HNSW.
- Reranking helps both TQ2 and TQ4, which suggests the gain is not tied to one quantizer setting.
- The 1M run preserves the same recall-throughput trade-off at a larger scale.

This PR therefore treats exact reranking as the main mechanism for quality recovery, not as a benchmark-specific tuning trick. TQ2 is the clearest demonstration: the direct compressed ranking can be much worse than Float32, yet the hybrid pipeline recovers Float32-like Recall@10 because the missing quality is mostly ordering quality, not candidate membership.

### 50k OpenAI embeddings

| Index | Build | RAM | efSearch | exact | Recall@10 | QPS |
|---|---:|---:|---:|---:|---:|---:|
| F32 | 7.18s | 236.6 MB | 64 | - | 97.39% | 6030 |
| TQ4 pure | 9.66s | 52.0 MB | 64 | - | 94.05% | 5852 |
| TQ4 + rerank | 9.66s | 52.0 MB | 64 | 20 | 97.40% | 6893 |
| TQ4 + rerank | 9.66s | 52.0 MB | 64 | 40 | 97.40% | 7759 |
| TQ2 pure | 9.07s | 32.9 MB | 64 | - | 86.00% | 7905 |
| TQ2 + rerank | 9.07s | 32.9 MB | 64 | 20 | 96.91% | 7370 |
| TQ2 + rerank | 9.07s | 32.9 MB | 64 | 40 | 97.36% | 8043 |

### 50k Cohere embeddings

| Index | Build | RAM | efSearch | exact | Recall@10 | QPS |
|---|---:|---:|---:|---:|---:|---:|
| F32 | 4.43s | 205.9 MB | 64 | - | 97.65% | 12375 |
| TQ4 pure | 5.16s | 39.0 MB | 64 | - | 91.01% | 15377 |
| TQ4 + rerank | 5.16s | 39.0 MB | 64 | 20 | 97.18% | 15125 |
| TQ4 + rerank | 5.16s | 39.0 MB | 64 | 40 | 97.20% | 15172 |
| TQ2 pure | 5.05s | 25.7 MB | 64 | - | 75.95% | 16238 |
| TQ2 + rerank | 5.05s | 25.7 MB | 64 | 20 | 93.11% | 15868 |
| TQ2 + rerank | 5.05s | 25.7 MB | 64 | 40 | 96.69% | 16194 |

### Recall-throughput sweep

OpenAI, TQ2 + exact rerank:

| efSearch | exact | Recall@10 | QPS |
|---:|---:|---:|---:|
| 16 | 20 | 88.22% | 16484 |
| 16 | 40 | 95.27% | 10835 |
| 32 | 20 | 93.48% | 12467 |
| 32 | 40 | 95.27% | 10782 |
| 64 | 20 | 96.91% | 7370 |
| 64 | 40 | 97.36% | 8043 |
| 128 | 20 | 98.18% | 4763 |
| 128 | 40 | 98.78% | 4211 |

Cohere, TQ2 + exact rerank:

| efSearch | exact | Recall@10 | QPS |
|---:|---:|---:|---:|
| 16 | 20 | 85.37% | 34065 |
| 16 | 40 | 94.09% | 22652 |
| 32 | 20 | 89.92% | 23921 |
| 32 | 40 | 94.09% | 21441 |
| 64 | 20 | 93.11% | 15868 |
| 64 | 40 | 96.69% | 16194 |
| 128 | 20 | 94.25% | 10135 |
| 128 | 40 | 98.23% | 9737 |

These sweeps show that reranking 20-40 candidates is enough to recover most of the quality lost by low-bit candidate generation. Larger candidate sets continue to improve recall, but with the expected throughput trade-off.

These results suggest not that TQ2 is a perfect final metric. It is not. These experiments indicate that TQ2 is good enough as a compact HNSW candidate generator, and exact reranking is cheap when applied to a few dozen candidates.

## Large-scale validation

The same pipeline was validated on **1M real OpenAI DBpedia embeddings**. The run used 1,000 queries and indexed the remaining 999,000 vectors.

Setup:

- 1,000,000 loaded vectors,
- 999,000 indexed vectors,
- 1536 dimensions,
- normalized Float32 matrix kept resident for ground truth and reranking,
- cosine similarity,
- exact Float32 ground truth.

The dataset was loaded shard-by-shard into a preallocated contiguous Float32 matrix. This avoids transient Python list/DataFrame amplification during the 1M load and keeps the memory measurement focused on the resident exact matrix plus the index under test.

Index memory below is reported as the direct process-RAM delta:

```text
RAM after index build - RAM immediately before index build
```

This avoids counting the external Float32 matrix, DuckDB/NumPy memory, or ground-truth allocation as index memory.

| Index | Build | Index RAM Delta | Recall@10 | QPS | Configuration |
|---|---:|---:|---:|---:|---|
| F32 | 368.25s | 5.95 GB | 97.34% | 2856 | ef=128 |
| TQ4 + rerank | 290.96s | 1.19 GB | 97.05% | 4407 | ef=128, exact=40 |
| TQ2 + rerank | 282.16s | 0.71 GB | 97.24% | 4790 | ef=128, exact=40 |

Measured index-memory reduction:

| Comparison | Reduction |
|---|---:|
| F32 / TQ4 | 5.00x |
| F32 / TQ2 | 8.38x |

This is the core large-scale result: TQ2 + exact reranking matches the F32 baseline within 0.10 Recall@10 points while reducing incremental index RAM from 5.95 GB to 0.71 GB.

Large-scale retrieval sweep for TQ2:

| efSearch | exact | Recall@1 | Recall@10 | QPS |
|---:|---:|---:|---:|---:|
| 16 | 10 | 72.90% | 76.22% | 16609 |
| 16 | 20 | 85.50% | 84.61% | 15455 |
| 16 | 40 | 91.90% | 91.85% | 10426 |
| 16 | 80 | 95.30% | 95.61% | 6154 |
| 16 | 100 | 95.90% | 96.47% | 5302 |
| 32 | 10 | 77.10% | 81.86% | 11726 |
| 32 | 20 | 89.90% | 89.54% | 11849 |
| 32 | 40 | 91.90% | 91.85% | 10651 |
| 32 | 80 | 95.30% | 95.61% | 6468 |
| 32 | 100 | 95.90% | 96.47% | 5539 |
| 64 | 10 | 79.90% | 84.99% | 7654 |
| 64 | 20 | 94.30% | 94.36% | 7141 |
| 64 | 40 | 94.30% | 94.79% | 7406 |
| 64 | 80 | 95.30% | 95.61% | 6492 |
| 64 | 100 | 95.90% | 96.47% | 5569 |
| 128 | 10 | 81.50% | 86.39% | 4801 |
| 128 | 20 | 96.50% | 96.69% | 4593 |
| 128 | 40 | 96.50% | 97.24% | 4790 |
| 128 | 80 | 96.50% | 97.24% | 4686 |
| 128 | 100 | 96.50% | 97.24% | 4608 |

## Compatibility

The implementation is opt-in and preserves existing Float32, Float16, BF16, integer, and binary scalar paths.

Existing users do not need to change code unless they want to build TQ2/TQ4 indexes or use exact reranking.

## Observation

An additional MRL truncation benchmark on `google/embeddinggemma-300m` Bloomberg embeddings validates an important boundary condition. TQ2 becomes much more fragile around 512 dimensions and fails clearly at 256/128 dimensions under the same `exact=40` operating point. At `efSearch=64`, TQ2 + rerank reaches 96.17% Recall@10 at 768d, 91.43% at 512d, 79.53% at 256d, and 59.11% at 128d. This is consistent with the expected behavior of ultra-low-bit candidate generation: with fewer dimensions, there is less redundancy for TQ2 to absorb quantization error before exact reranking. TQ4 degrades more gracefully in the same benchmark.

| MRL Dimension | F32 Recall@10 | TQ4 + Rerank | TQ2 + Rerank |
| ------------: | ------------: | -----------: | -----------: |
|           768 |          ~98% |         ~98% |   **96.17%** |
|           512 |          ~98% |         ~97% |   **91.43%** |
|           256 |    **98.12%** |   **96.41%** |   **79.52%** |
|           128 |          ~97% |         ~90% |   **59.11%** |
