### PR TITLE
Improve: cache cosine norms for dense search

### DIFF
--- a/c/test.c
+++ b/c/test.c
@@ -16,6 +16,7 @@
  *  faulting frame instead of stopping at a bare exit code.
  */
 #include <errno.h>
+#include <math.h>
 #include <signal.h> // `signal`, `raise`, `SIGSEGV`
 #include <stdio.h>  // `remove`
 #include <stdlib.h>
@@ -488,6 +489,330 @@ void test_mini_float_quantizations(size_t const collection_size, size_t const di
     printf("Test: Mini-float quantizations - PASSED\n");
 }
 
+static size_t counted_cosine_calls = 0;
+
+usearch_distance_t counted_cosine_f32(void const* first_ptr, void const* second_ptr) {
+    float const* first = (float const*)first_ptr;
+    float const* second = (float const*)second_ptr;
+    float dot = 0, first_norm = 0, second_norm = 0;
+    ++counted_cosine_calls;
+    for (size_t dimension = 0; dimension != 3; ++dimension) {
+        dot += first[dimension] * second[dimension];
+        first_norm += first[dimension] * first[dimension];
+        second_norm += second[dimension] * second[dimension];
+    }
+    if (first_norm == 0)
+        return second_norm == 0 ? 0 : 1;
+    if (second_norm == 0)
+        return 1;
+    return 1 - dot / (sqrtf(first_norm) * sqrtf(second_norm));
+}
+
+int keep_even_keys(usearch_key_t key, void* state) {
+    size_t* calls = (size_t*)state;
+    ++*calls;
+    return (key % 2) == 0;
+}
+
+static void expect_distance_for_key(usearch_key_t const* keys, float const* distances, size_t count,
+                                    usearch_key_t key, float expected, float tolerance) {
+    for (size_t i = 0; i != count; ++i)
+        if (keys[i] == key) {
+            expect(fabsf(distances[i] - expected) <= tolerance, "Unexpected cosine distance");
+            return;
+        }
+    expect(false, "Expected cosine key is missing");
+}
+
+void expect_cosine_results(usearch_index_t index, void const* query, usearch_scalar_kind_t query_kind,
+                           size_t expected_count, float tolerance) {
+    usearch_error_t error = NULL;
+    usearch_key_t keys[8] = {0};
+    float distances[8] = {0};
+    usearch_key_t const known_keys[] = {10, 21, 30, 41, 50};
+    size_t found = usearch_search(index, query, query_kind, expected_count, keys, distances, &error);
+    expect(!error, error);
+    expect_eq(found, expected_count, "Unexpected cosine result count");
+    for (size_t i = 0; i != found; ++i) {
+        expect(distances[i] >= 0 && distances[i] <= 2 + tolerance, "Invalid cosine distance range");
+        if (i)
+            expect(distances[i - 1] <= distances[i] + tolerance, "Cosine results are not ordered");
+        bool known = false;
+        for (size_t j = 0; j != sizeof(known_keys) / sizeof(known_keys[0]); ++j)
+            known = known || keys[i] == known_keys[j];
+        expect(known, "Cosine result contains an invalid key");
+        for (size_t j = 0; j != i; ++j)
+            expect(keys[j] != keys[i], "Cosine result contains a duplicate key");
+    }
+}
+
+static bool files_equal(char const* first_path, char const* second_path) {
+    FILE* first = fopen(first_path, "rb");
+    FILE* second = fopen(second_path, "rb");
+    if (!first || !second) {
+        if (first)
+            fclose(first);
+        if (second)
+            fclose(second);
+        return false;
+    }
+    bool equal = true;
+    while (equal) {
+        unsigned char first_bytes[256], second_bytes[256];
+        size_t first_count = fread(first_bytes, 1, sizeof(first_bytes), first);
+        size_t second_count = fread(second_bytes, 1, sizeof(second_bytes), second);
+        equal = first_count == second_count && memcmp(first_bytes, second_bytes, first_count) == 0;
+        if (!first_count || !second_count)
+            break;
+    }
+    fclose(first);
+    fclose(second);
+    return equal;
+}
+
+static size_t test_cosine_norm_cache_kind(usearch_scalar_kind_t quantization, char const* saved_path,
+                                          char const* roundtrip_path, float tolerance) {
+    float const vectors[5][3] = {
+        {1, 0, 0},
+        {0, 1, 0},
+        {-1, 0, 0},
+        {0, 0, 0},
+        {1, 1, 0},
+    };
+    usearch_key_t const vector_keys[5] = {10, 21, 30, 41, 50};
+    float const query_x[3] = {1, 0, 0};
+    float const query_zero[3] = {0, 0, 0};
+    float const query_z[3] = {0, 0, 1};
+    double const query_x_f64[3] = {1, 0, 0};
+    float const replacement[3] = {0, 0, 1};
+    usearch_key_t keys[8] = {0};
+    float distances[8] = {0};
+    usearch_error_t error = NULL;
+
+    usearch_init_options_t options = create_options(3);
+    options.metric_kind = usearch_metric_cos_k;
+    options.quantization = quantization;
+    usearch_index_t index = usearch_init(&options, &error);
+    expect(!error && index, error);
+    usearch_reserve(index, 8, &error);
+    expect(!error, error);
+    size_t reserved_memory = usearch_memory_usage(index, &error);
+    expect(reserved_memory > 8 * sizeof(uint32_t), "Cosine memory accounting is incomplete");
+
+    for (size_t i = 0; i != 5; ++i) {
+        usearch_add(index, vector_keys[i], vectors[i], usearch_scalar_f32_k, &error);
+        expect(!error, error);
+    }
+
+    expect_cosine_results(index, query_x, usearch_scalar_f32_k, 5, tolerance);
+    size_t found = usearch_search(index, query_x, usearch_scalar_f32_k, 5, keys, distances, &error);
+    expect_distance_for_key(keys, distances, found, 10, 0, tolerance);
+    expect_distance_for_key(keys, distances, found, 50, 0.29289323f, tolerance);
+    expect_distance_for_key(keys, distances, found, 21, 1, tolerance);
+    expect_distance_for_key(keys, distances, found, 41, 1, tolerance);
+    expect_distance_for_key(keys, distances, found, 30, 2, tolerance);
+
+    expect_cosine_results(index, query_zero, usearch_scalar_f32_k, 5, tolerance);
+    found = usearch_search(index, query_zero, usearch_scalar_f32_k, 5, keys, distances, &error);
+    expect_distance_for_key(keys, distances, found, 41, 0, tolerance);
+    for (size_t i = 0; i != found; ++i)
+        if (keys[i] != 41)
+            expect(fabsf(distances[i] - 1) <= tolerance, "One-zero cosine semantics changed");
+
+    found = usearch_search(index, query_x_f64, usearch_scalar_f64_k, 5, keys, distances, &error);
+    expect(!error, error);
+    expect_eq(found, 5, "f64 cosine query cast lost results");
+    expect_distance_for_key(keys, distances, found, 10, 0, tolerance);
+
+    size_t filter_calls = 0;
+    found = usearch_filtered_search(index, query_x, usearch_scalar_f32_k, 5, &keep_even_keys, &filter_calls, keys,
+                                    distances, &error);
+    expect(!error, error);
+    expect_eq(found, 3, "Filtered cosine search returned the wrong count");
+    expect(filter_calls > 0, "Cosine filter was not invoked");
+    for (size_t i = 0; i != found; ++i)
+        expect((keys[i] % 2) == 0, "Cosine filter admitted an odd key");
+
+    expect_eq(usearch_remove(index, 10, &error), 1, "Failed to remove cached cosine vector");
+    expect(!error, error);
+    usearch_add(index, 10, replacement, usearch_scalar_f32_k, &error);
+    expect(!error, error);
+    found = usearch_search(index, query_z, usearch_scalar_f32_k, 5, keys, distances, &error);
+    expect(!error && found == 5, error);
+    expect_distance_for_key(keys, distances, found, 10, 0, tolerance);
+    found = usearch_search(index, query_x, usearch_scalar_f32_k, 5, keys, distances, &error);
+    expect_distance_for_key(keys, distances, found, 10, 1, tolerance);
+
+    size_t serialized_length = usearch_serialized_length(index, &error);
+    usearch_save(index, saved_path, &error);
+    expect(!error, error);
+    struct stat saved_stat;
+    expect(stat(saved_path, &saved_stat) == 0, "Failed to stat saved cosine index");
+    expect_eq((size_t)saved_stat.st_size, serialized_length, "Serialized cosine length differs from file bytes");
+
+    usearch_index_t loaded = usearch_init(NULL, &error);
+    expect(!error && loaded, error);
+    usearch_load(loaded, saved_path, &error);
+    expect(!error, error);
+    found = usearch_search(loaded, query_z, usearch_scalar_f32_k, 5, keys, distances, &error);
+    expect(!error && found == 5, error);
+    expect_distance_for_key(keys, distances, found, 10, 0, tolerance);
+    expect(usearch_memory_usage(loaded, &error) > 0, "Loaded cosine index did not report memory");
+    usearch_save(loaded, roundtrip_path, &error);
+    expect(!error, error);
+    struct stat roundtrip_stat;
+    expect(stat(roundtrip_path, &roundtrip_stat) == 0, "Failed to stat round-tripped cosine index");
+    expect_eq((size_t)roundtrip_stat.st_size, serialized_length, "Round-trip changed serialized cosine length");
+    expect(files_equal(saved_path, roundtrip_path), "Cosine norm cache changed serialized bytes");
+
+    usearch_index_t viewed = usearch_init(NULL, &error);
+    expect(!error && viewed, error);
+    usearch_view(viewed, saved_path, &error);
+    expect(!error, error);
+    found = usearch_search(viewed, query_z, usearch_scalar_f32_k, 5, keys, distances, &error);
+    expect(!error && found == 5, error);
+    expect_distance_for_key(keys, distances, found, 10, 0, tolerance);
+
+    usearch_clear(index, &error);
+    expect(!error && usearch_size(index, &error) == 0, error);
+    usearch_add(index, 77, query_x, usearch_scalar_f32_k, &error);
+    expect(!error, error);
+    found = usearch_search(index, query_x, usearch_scalar_f32_k, 1, keys, distances, &error);
+    expect(!error && found == 1 && keys[0] == 77 && distances[0] <= tolerance,
+           "Cosine cache did not recover after clear");
+
+    usearch_free(viewed, &error);
+    usearch_free(loaded, &error);
+    usearch_free(index, &error);
+    remove(saved_path);
+    remove(roundtrip_path);
+    return reserved_memory;
+}
+
+static void test_nonfinite_cosine_fallback(void) {
+    usearch_error_t error = NULL;
+    usearch_init_options_t options = create_options(2);
+    options.metric_kind = usearch_metric_cos_k;
+    options.quantization = usearch_scalar_f32_k;
+    usearch_index_t index = usearch_init(&options, &error);
+    expect(!error && index, error);
+    usearch_reserve(index, 4, &error);
+    expect(!error, error);
+
+    uint32_t nan_bits = 0x7fc00001u, inf_bits = 0x7f800000u;
+    float nan_value = 0, inf_value = 0;
+    memcpy(&nan_value, &nan_bits, sizeof(nan_value));
+    memcpy(&inf_value, &inf_bits, sizeof(inf_value));
+    float const finite_vector[2] = {1, 0};
+    float const zero_vector[2] = {0, 0};
+    float const nan_vector[2] = {nan_value, 1};
+    float const inf_vector[2] = {inf_value, 1};
+    usearch_add(index, 1, finite_vector, usearch_scalar_f32_k, &error);
+    usearch_add(index, 2, zero_vector, usearch_scalar_f32_k, &error);
+    usearch_add(index, 3, nan_vector, usearch_scalar_f32_k, &error);
+    usearch_add(index, 4, inf_vector, usearch_scalar_f32_k, &error);
+    expect(!error, error);
+
+    usearch_key_t keys[4] = {0};
+    float distances[4] = {0};
+    size_t found = usearch_search(index, finite_vector, usearch_scalar_f32_k, 4, keys, distances, &error);
+    expect(!error && found > 0 && found <= 4, "Nonfinite member fallback failed");
+    found = usearch_search(index, nan_vector, usearch_scalar_f32_k, 4, keys, distances, &error);
+    expect(!error && found > 0 && found <= 4, "Nonfinite query fallback failed");
+    usearch_free(index, &error);
+
+    options.quantization = usearch_scalar_bf16_k;
+    index = usearch_init(&options, &error);
+    expect(!error && index, error);
+    usearch_reserve(index, 3, &error);
+    expect(!error, error);
+    uint16_t const bf16_finite[2] = {0x3f80u, 0};
+    uint16_t const bf16_nan[2] = {0x7fc1u, 0x3f80u};
+    uint16_t const bf16_inf[2] = {0x7f80u, 0x3f80u};
+    usearch_add(index, 1, bf16_finite, usearch_scalar_bf16_k, &error);
+    usearch_add(index, 2, bf16_nan, usearch_scalar_bf16_k, &error);
+    usearch_add(index, 3, bf16_inf, usearch_scalar_bf16_k, &error);
+    expect(!error, error);
+    found = usearch_search(index, bf16_finite, usearch_scalar_bf16_k, 3, keys, distances, &error);
+    expect(!error && found > 0 && found <= 3, "Raw bf16 nonfinite member fallback failed");
+    found = usearch_search(index, bf16_nan, usearch_scalar_bf16_k, 3, keys, distances, &error);
+    expect(!error && found > 0 && found <= 3, "Raw bf16 nonfinite query fallback failed");
+    usearch_free(index, &error);
+}
+
+void test_cosine_norm_cache(void) {
+    printf("Test: Cosine norm cache...\n");
+    size_t f32_cosine_memory = test_cosine_norm_cache_kind(
+        usearch_scalar_f32_k, "tmp_cosine_norm_f32.usearch", "tmp_cosine_norm_f32_roundtrip.usearch", 2e-5f);
+    size_t bf16_cosine_memory = test_cosine_norm_cache_kind(
+        usearch_scalar_bf16_k, "tmp_cosine_norm_bf16.usearch", "tmp_cosine_norm_bf16_roundtrip.usearch", 2e-3f);
+
+    // Without NumKong the library reports exactly "serial" and routes built-in metrics through the auto-vectorized
+    // kernels, which are the only ones eligible for the norm sidecar. With NumKong compiled in, the built-in cosine
+    // kernels come from NumKong and no sidecar may ever be allocated. Either way the accounting must be exact.
+    bool const expect_sidecar = strcmp(usearch_hardware_acceleration_compiled(), "serial") == 0;
+    size_t const expected_sidecar_bytes = expect_sidecar ? 8 * sizeof(uint32_t) : 0;
+
+    usearch_error_t error = NULL;
+    usearch_init_options_t options = create_options(3);
+    options.metric_kind = usearch_metric_l2sq_k;
+    options.quantization = usearch_scalar_f32_k;
+    usearch_index_t changed_metric = usearch_init(&options, &error);
+    expect(!error && changed_metric, error);
+    usearch_reserve(changed_metric, 8, &error);
+    expect(!error, error);
+    size_t l2_reserved_memory = usearch_memory_usage(changed_metric, &error);
+    expect_eq(f32_cosine_memory, l2_reserved_memory + expected_sidecar_bytes,
+              "f32 cosine sidecar memory accounting is incorrect");
+    expect_eq(bf16_cosine_memory, l2_reserved_memory + expected_sidecar_bytes,
+              "bf16 cosine sidecar memory accounting is incorrect");
+
+    float const callback_vectors[3][3] = {{1, 0, 0}, {0, 1, 0}, {0, 0, 0}};
+    for (size_t i = 0; i != 3; ++i)
+        usearch_add(changed_metric, i + 1, callback_vectors[i], usearch_scalar_f32_k, &error);
+    expect(!error, error);
+    size_t memory_before_change = usearch_memory_usage(changed_metric, &error);
+    usearch_change_metric_kind(changed_metric, usearch_metric_cos_k, &error);
+    expect(!error, error);
+    size_t memory_after_change = usearch_memory_usage(changed_metric, &error);
+    expect_eq(memory_after_change, memory_before_change + expected_sidecar_bytes,
+              "Changing to cosine reported an invalid sidecar size");
+    usearch_key_t keys[3] = {0};
+    float distances[3] = {0};
+    size_t found = usearch_search(changed_metric, callback_vectors[0], usearch_scalar_f32_k, 3, keys, distances, &error);
+    expect(!error && found == 3, "Changed-metric cosine search failed");
+    // After the change the index must behave exactly like a cosine index built from scratch: the query {1,0,0}
+    // is at distance 0 from key 1, orthogonal (distance 1) to key 2, and at distance 1 from the zero vector, key 3.
+    expect_distance_for_key(keys, distances, found, 1, 0, 2e-5f);
+    expect_distance_for_key(keys, distances, found, 2, 1, 2e-5f);
+    expect_distance_for_key(keys, distances, found, 3, 1, 2e-5f);
+    usearch_change_metric_kind(changed_metric, usearch_metric_l2sq_k, &error);
+    expect(!error, error);
+    expect_eq(usearch_memory_usage(changed_metric, &error), memory_before_change,
+              "Changing away from cosine did not release the sidecar");
+    usearch_free(changed_metric, &error);
+
+    options.metric_kind = usearch_metric_cos_k;
+    options.metric = &counted_cosine_f32;
+    usearch_index_t callback_index = usearch_init(&options, &error);
+    expect(!error && callback_index, error);
+    usearch_reserve(callback_index, 8, &error);
+    expect(!error, error);
+    expect_eq(usearch_memory_usage(callback_index, &error), l2_reserved_memory,
+              "Cosine-labelled callback incorrectly allocated a norm sidecar");
+    for (size_t i = 0; i != 3; ++i)
+        usearch_add(callback_index, i + 1, callback_vectors[i], usearch_scalar_f32_k, &error);
+    expect(!error, error);
+    counted_cosine_calls = 0;
+    found = usearch_search(callback_index, callback_vectors[0], usearch_scalar_f32_k, 3, keys, distances, &error);
+    expect(!error && found == 3, "Cosine callback search failed");
+    expect(counted_cosine_calls > 0, "Built-in cosine cache captured a custom callback");
+    usearch_free(callback_index, &error);
+
+    test_nonfinite_cosine_fallback();
+    printf("Test: Cosine norm cache - PASSED\n");
+}
+
 int main(int argc, char const* argv[]) {
     install_crash_handlers();
     printf("Running tests...\n");
@@ -507,6 +832,8 @@ int main(int argc, char const* argv[]) {
             test_mini_float_quantizations(collection_sizes[index], dimensions[jdx]);
         }
     }
+
+    test_cosine_norm_cache();
 
     (void)argc;
     (void)argv;

--- a/cpp/test.cpp
+++ b/cpp/test.cpp
@@ -20,6 +20,7 @@
 #include <limits>  // `std::numeric_limits`
 
 #include <algorithm>     // `std::shuffle`
+#include <atomic>        // `std::atomic`
 #include <random>        // `std::default_random_engine`
 #include <stdexcept>     // `std::terminate`
 #include <unordered_map> // `std::unordered_map`
@@ -54,6 +55,24 @@
 
 #define SZ_USE_X86_AVX512 0            // Sanitizers hate AVX512
 #include <stringzilla/stringzilla.hpp> // Levenshtein distance implementation
+
+/**
+ *  Counters for the cosine norm cache diagnostic hook in `index_dense.hpp`. They let the tests assert that the
+ *  sidecar route is actually taken, not just that results are correct, which a fallback would also deliver.
+ */
+struct cosine_cache_diagnostics_t {
+    // Atomic so that the concurrent add/search test is race-free under ThreadSanitizer.
+    std::atomic<std::size_t> cache_hit_{0}, invalid_fallback_{0}, population_{0}, route_bypass_{0},
+        query_preparation_{0};
+    std::size_t cache_hit() const { return cache_hit_.load(); }
+    std::size_t invalid_fallback() const { return invalid_fallback_.load(); }
+    std::size_t population() const { return population_.load(); }
+    std::size_t route_bypass() const { return route_bypass_.load(); }
+    std::size_t query_preparation() const { return query_preparation_.load(); }
+    void reset() { cache_hit_ = invalid_fallback_ = population_ = route_bypass_ = query_preparation_ = 0; }
+};
+static cosine_cache_diagnostics_t cosine_cache_diagnostics;
+#define USEARCH_COSINE_NORM_CACHE_DIAGNOSTIC(event) (++cosine_cache_diagnostics.event##_)
 
 #include <usearch/index.hpp>
 #include <usearch/index_dense.hpp>
@@ -1374,6 +1393,291 @@ static void install_crash_handlers() {
 }
 
 /**
+ *  @brief  Cosine norm sidecar: verifies through the diagnostic hook that the fast route is taken exactly when it
+ *          should be, that every lifecycle path keeps the sidecar populated, and that distances match the reference
+ *          `metric_cos_gt` kernel within floating-point noise.
+ */
+template <typename scalar_at> void test_cosine_norm_cache(std::size_t count, std::size_t dimensions) {
+
+    using vector_key_t = std::int64_t;
+    using slot_t = std::uint32_t;
+    using index_t = index_dense_gt<vector_key_t, slot_t>;
+    cosine_cache_diagnostics_t& diag = cosine_cache_diagnostics;
+
+    scalar_kind_t const kind = scalar_kind<scalar_at>();
+    bool const with_bf16 = kind == scalar_kind_t::bf16_k;
+    float const tolerance = with_bf16 ? 2e-3f : 2e-5f;
+
+    // Deterministic data with mixed signs and magnitudes, plus one zero vector.
+    std::vector<std::vector<scalar_at>> vectors(count, std::vector<scalar_at>(dimensions));
+    std::mt19937 generator(42);
+    std::uniform_real_distribution<float> distribution(-1.f, 1.f);
+    for (std::size_t i = 0; i != count; ++i)
+        for (std::size_t d = 0; d != dimensions; ++d)
+            vectors[i][d] = static_cast<scalar_at>(i + 1 == count ? 0.f : distribution(generator) * float(1 + i % 7));
+    std::vector<scalar_at> const& query = vectors[0];
+
+    metric_punned_t const builtin(dimensions, metric_kind_t::cos_k, kind);
+    metric_punned_t const l2(dimensions, metric_kind_t::l2sq_k, kind);
+    // The sidecar applies to the built-in auto-vectorized cosine kernels only. Without NumKong they are the
+    // built-in kernels, so the route must be active; with NumKong the kernels come from NumKong and it must not.
+    bool const sidecar_expected = builtin.supports_cosine_norm_cache();
+    if (!USEARCH_USE_NUMKONG)
+        expect(sidecar_expected);
+
+    // Two references. `true_cosine` is the reference kernel `metric_cos_gt`, independent of how the index computes
+    // distances; it is the right yardstick whenever the sidecar route is active (the route must reproduce true
+    // cosine) and for the user-kernel index below, whose kernel is exactly `metric_cos_gt`. When the route is
+    // inactive (NumKong builds), the only guarantee is pass-through of the configured kernel, whose bf16 results
+    // legitimately differ from `metric_cos_gt` by more than the tolerance, so the configured metric is the
+    // reference there.
+    auto true_cosine = [&](scalar_at const* a, scalar_at const* b) -> float {
+        return metric_cos_gt<scalar_at, float>{}(a, b, dimensions);
+    };
+    auto configured = [&](scalar_at const* a, scalar_at const* b) -> float {
+        return builtin(reinterpret_cast<byte_t const*>(a), reinterpret_cast<byte_t const*>(b));
+    };
+    float const self_tolerance = sidecar_expected ? tolerance : 10 * tolerance;
+    // Exact search scores every live member through the same proxy that approximate search uses. Members are
+    // resolved by key against the original data, since the sidecar is addressed by slot and slots move on `compact`.
+    std::vector<scalar_at> replacement(dimensions);
+    for (std::size_t d = 0; d != dimensions; ++d)
+        replacement[d] = static_cast<scalar_at>(d % 2 ? 1.f : -1.f);
+    // `replaced` says whether key 1 holds `replacement` in the index being checked (the primary index and its
+    // copies do, after the re-insertion below; every other index keeps the original vector).
+    auto expect_matches_reference = [&](index_t const& index, std::vector<scalar_at> const& q, bool replaced,
+                                        bool independent_reference) {
+        auto result = index.search(q.data(), index.size(), 0, true);
+        expect(result);
+        expect_eq(result.size(), index.size());
+        for (std::size_t i = 0; i != result.size(); ++i) {
+            auto match = result[i];
+            vector_key_t key = vector_key_t(match.member.key);
+            scalar_at const* member = replaced && key == 1 ? replacement.data() : vectors[std::size_t(key)].data();
+            float expected = independent_reference ? true_cosine(q.data(), member) : configured(q.data(), member);
+            expect(std::abs(match.distance - expected) <= tolerance);
+            if (i)
+                expect(result[i - 1].distance <= match.distance + tolerance);
+        }
+    };
+    auto expect_route = [&](bool used) {
+        expect_eq(diag.query_preparation() > 0, used);
+        expect_eq(diag.cache_hit() > 0, used);
+        expect_eq(diag.invalid_fallback(), std::size_t(0));
+    };
+
+    // --- Reference L2 twin, measured right after `reserve`, before any vectors are copied in. ---
+    auto l2_made = index_t::make(l2);
+    expect(l2_made);
+    index_t& l2_index = l2_made.index;
+    expect(l2_index.try_reserve(count));
+    std::size_t const l2_reserved_memory = l2_index.memory_usage();
+    std::size_t const sidecar_bytes = sidecar_expected ? l2_index.capacity() * sizeof(std::uint32_t) : 0;
+
+    // --- Fresh cosine index: exactly 4 bytes per capacity slot, populated on insertion, served from the sidecar. ---
+    auto made = index_t::make(builtin);
+    expect(made);
+    index_t& index = made.index;
+    expect(index.try_reserve(count));
+    expect_eq(index.capacity(), l2_index.capacity());
+    expect_eq(index.memory_usage(), l2_reserved_memory + sidecar_bytes);
+    diag.reset();
+    for (std::size_t i = 0; i != count; ++i)
+        expect(index.add(vector_key_t(i), vectors[i].data()));
+    expect_eq(diag.population(), sidecar_expected ? count : std::size_t(0));
+    diag.reset();
+    expect_matches_reference(index, query, false, sidecar_expected);
+    expect_route(sidecar_expected);
+    diag.reset();
+    {
+        auto approximate = index.search(query.data(), 5);
+        expect(approximate);
+        expect_eq(approximate.size(), std::size_t(5));
+        expect_eq(vector_key_t(approximate[0].member.key), vector_key_t(0));
+        expect(std::abs(approximate[0].distance) <= self_tolerance);
+    }
+    expect_route(sidecar_expected);
+
+    // --- Metric change L2 -> cosine must populate; cosine -> L2 must release; equivalent cosine preserves. ---
+    for (std::size_t i = 0; i != count; ++i)
+        expect(l2_index.add(vector_key_t(i), vectors[i].data()));
+    std::size_t const l2_memory = l2_index.memory_usage();
+    diag.reset();
+    expect(l2_index.try_change_metric(metric_punned_t(dimensions, metric_kind_t::cos_k, kind)));
+    expect_eq(diag.population(), sidecar_expected ? count : std::size_t(0));
+    expect_eq(l2_index.memory_usage(), l2_memory + sidecar_bytes);
+    diag.reset();
+    expect_matches_reference(l2_index, query, false, sidecar_expected);
+    expect_route(sidecar_expected);
+    expect(l2_index.try_change_metric(metric_punned_t(dimensions, metric_kind_t::l2sq_k, kind)));
+    expect_eq(l2_index.memory_usage(), l2_memory);
+    expect(l2_index.try_change_metric(metric_punned_t(dimensions, metric_kind_t::cos_k, kind)));
+    diag.reset();
+    expect(l2_index.try_change_metric(metric_punned_t(dimensions, metric_kind_t::cos_k, kind)));
+    expect_eq(diag.population(), std::size_t(0));
+    diag.reset();
+    expect_matches_reference(l2_index, query, false, sidecar_expected);
+    expect_route(sidecar_expected);
+
+    // --- Remove and re-insert a key: the slot is invalidated, then repopulated with the new norm. ---
+    expect(index.remove(vector_key_t(1)));
+    diag.reset();
+    expect(index.add(vector_key_t(1), replacement.data()));
+    expect_eq(diag.population(), sidecar_expected ? std::size_t(1) : std::size_t(0));
+    diag.reset();
+    expect_matches_reference(index, replacement, true, sidecar_expected);
+    expect_route(sidecar_expected);
+    {
+        auto top = index.search(replacement.data(), 1);
+        expect_eq(top.size(), std::size_t(1));
+        expect_eq(vector_key_t(top[0].member.key), vector_key_t(1));
+        expect(std::abs(top[0].distance) <= self_tolerance);
+    }
+
+    // --- Compaction rebuilds the sidecar for the remapped slots. ---
+    expect(index.remove(vector_key_t(2)));
+    diag.reset();
+    expect(index.compact());
+    expect_eq(diag.population(), sidecar_expected ? index.size() : std::size_t(0));
+    diag.reset();
+    expect_matches_reference(index, query, true, sidecar_expected);
+    expect_route(sidecar_expected);
+
+    // --- Copy duplicates a valid sidecar instead of recomputing it. ---
+    diag.reset();
+    auto copied = index.copy();
+    expect(copied);
+    expect_eq(diag.population(), std::size_t(0));
+    diag.reset();
+    expect_matches_reference(copied.index, query, true, sidecar_expected);
+    expect_route(sidecar_expected);
+
+    // --- Serialization: the sidecar is never written, rebuilt on load, absent for memory-mapped views. ---
+    char const* path = "tmp_cosine_norm_cache.usearch";
+    expect(index.save(path));
+    auto loaded = index_t::make(builtin);
+    expect(loaded);
+    diag.reset();
+    expect(loaded.index.load(path));
+    expect_eq(diag.population(), sidecar_expected ? index.size() : std::size_t(0));
+    diag.reset();
+    expect_matches_reference(loaded.index, query, true, sidecar_expected);
+    expect_route(sidecar_expected);
+    auto viewed = index_t::make(builtin);
+    expect(viewed);
+    expect(viewed.index.view(path));
+    diag.reset();
+    expect_matches_reference(viewed.index, query, true, sidecar_expected);
+    expect_route(false);
+    expect(diag.route_bypass() > 0);
+    std::remove(path);
+
+    // --- Indexes that don't own their vectors never allocate a sidecar. ---
+    index_dense_config_t external_config;
+    external_config.exclude_vectors = true;
+    auto external = index_t::make(builtin, external_config);
+    expect(external);
+    expect(external.index.try_reserve(count));
+    expect_eq(external.index.memory_usage(), l2_reserved_memory);
+    diag.reset();
+    for (std::size_t i = 0; i != count; ++i)
+        expect(external.index.add(vector_key_t(i), vectors[i].data()));
+    expect_eq(diag.population(), std::size_t(0));
+    diag.reset();
+    expect_matches_reference(external.index, query, false, sidecar_expected);
+    expect_route(false);
+
+    // --- A cosine-labelled user callback with the three-argument signature must not be captured, even when an
+    //     identical-code-folding linker merges the trampolines: provenance is the kernel address, not the trampoline.
+    {
+        static std::size_t user_calls = 0;
+        user_calls = 0;
+        auto user_kernel = +[](std::uintptr_t a_ptr, std::uintptr_t b_ptr, std::uintptr_t n) -> distance_punned_t {
+            ++user_calls;
+            return metric_cos_gt<scalar_at, float>{}((scalar_at const*)a_ptr, (scalar_at const*)b_ptr, n);
+        };
+        metric_punned_t user_metric = metric_punned_t::stateless(dimensions, (std::uintptr_t)user_kernel,
+                                                                 metric_punned_signature_t::array_array_size_k,
+                                                                 metric_kind_t::cos_k, kind);
+        expect(!user_metric.supports_cosine_norm_cache());
+        auto user_made = index_t::make(user_metric);
+        expect(user_made);
+        expect(user_made.index.try_reserve(count));
+        expect_eq(user_made.index.memory_usage(), l2_reserved_memory);
+        for (std::size_t i = 0; i != count; ++i)
+            expect(user_made.index.add(vector_key_t(i), vectors[i].data()));
+        diag.reset();
+        user_calls = 0;
+        expect_matches_reference(user_made.index, query, false, true);
+        expect_route(false);
+        expect(user_calls >= count);
+    }
+
+    // --- Non-finite members fall back per comparison; a non-finite query bypasses the route entirely. ---
+    if (!with_bf16) {
+        std::vector<scalar_at> nan_vector(dimensions, static_cast<scalar_at>(1.f));
+        nan_vector[0] = static_cast<scalar_at>(std::numeric_limits<float>::quiet_NaN());
+        auto nonfinite = index_t::make(builtin);
+        expect(nonfinite);
+        expect(nonfinite.index.try_reserve(count + 1));
+        for (std::size_t i = 0; i != count; ++i)
+            expect(nonfinite.index.add(vector_key_t(i), vectors[i].data()));
+        diag.reset();
+        expect(nonfinite.index.add(vector_key_t(count), nan_vector.data()));
+        expect_eq(diag.population(), std::size_t(0));
+        diag.reset();
+        auto result = nonfinite.index.search(query.data(), count + 1, 0, true);
+        expect(result);
+        expect_eq(result.size(), count + 1);
+        expect_eq(diag.invalid_fallback(), sidecar_expected ? std::size_t(1) : std::size_t(0));
+        expect_eq(diag.cache_hit(), sidecar_expected ? count : std::size_t(0));
+        diag.reset();
+        auto nan_result = nonfinite.index.search(nan_vector.data(), count + 1, 0, true);
+        expect(nan_result);
+        expect_eq(nan_result.size(), count + 1);
+        expect_eq(diag.query_preparation(), std::size_t(0));
+        expect_eq(diag.cache_hit(), std::size_t(0));
+        // The rejected query norm is reported once as a fallback, then the whole search bypasses the route.
+        expect_eq(diag.invalid_fallback(), sidecar_expected ? std::size_t(1) : std::size_t(0));
+        expect(diag.route_bypass() > 0);
+    }
+
+    // --- Concurrent insertions and searches share the sidecar without locks; every result must stay finite and
+    //     ordered, and once the writers finish every slot must be populated. ---
+    {
+        auto concurrent = index_t::make(builtin);
+        expect(concurrent);
+        std::size_t const threads = 8;
+        expect(concurrent.index.try_reserve({count, threads}));
+        for (std::size_t i = 0; i != count / 2; ++i)
+            expect(concurrent.index.add(vector_key_t(i), vectors[i].data(), i % threads));
+        diag.reset();
+        executor_default_t executor(threads);
+        std::atomic<std::size_t> searches_done{0};
+        executor.fixed(count, [&](std::size_t thread, std::size_t task) {
+            if (task < count / 2) {
+                auto result = concurrent.index.search(vectors[task].data(), 5, thread);
+                expect(result);
+                for (std::size_t i = 0; i != result.size(); ++i) {
+                    auto match = result[i];
+                    expect(match.distance >= -tolerance && match.distance <= 2 + tolerance);
+                    if (i)
+                        expect(result[i - 1].distance <= match.distance + tolerance);
+                }
+                ++searches_done;
+            } else
+                expect(concurrent.index.add(vector_key_t(task), vectors[task].data(), thread));
+        });
+        expect_eq(searches_done.load(), count / 2);
+        expect_eq(concurrent.index.size(), count);
+        expect_eq(diag.population(), sidecar_expected ? count - count / 2 : std::size_t(0));
+        diag.reset();
+        expect_matches_reference(concurrent.index, query, false, sidecar_expected);
+        expect_route(sidecar_expected);
+    }
+}
+
+/**
  *  @brief  Regression test: `make(metric, config)` must return an index that is
  *          immediately usable - no explicit `reserve` required before `load` /
  *          `view` / `search`. Previously the typed graph's `{0, 0}` thread
@@ -1584,6 +1888,9 @@ int main(int, char**) {
 
     test_filtered_search();
     test_isolate();
+    std::printf("Testing cosine norm cache\n");
+    test_cosine_norm_cache<f32_t>(64, 33);
+    test_cosine_norm_cache<bf16_t>(64, 33);
     test_load_after_metric_make();
     test_view_of_truncated_file();
     return 0;

--- a/include/usearch/index_dense.hpp
+++ b/include/usearch/index_dense.hpp
@@ -15,6 +15,10 @@
 #include <shared_mutex> // `std::shared_mutex`
 #endif
 
+#if !defined(USEARCH_COSINE_NORM_CACHE_DIAGNOSTIC)
+#define USEARCH_COSINE_NORM_CACHE_DIAGNOSTIC(event) ((void)0)
+#endif
+
 namespace unum {
 namespace usearch {
 
@@ -433,6 +437,44 @@ class index_dense_gt {
     using member_iterator_t = typename index_t::member_iterator_t;
     using member_citerator_t = typename index_t::member_citerator_t;
 
+    /**
+     *  @brief  Cosine norm sidecar entry. Searches read entries while concurrent insertions publish them, so every
+     *          slot is a lock-free 32-bit atomic: insertion and removal store with release semantics after the
+     *          vector bytes are written, searches load with acquire semantics before reading the vector bytes,
+     *          and bulk maintenance that runs without concurrent insertions (reserve, clear, compact, copy, load,
+     *          metric changes) uses relaxed accesses. On x86 these are plain moves; on weakly ordered CPUs they
+     *          also guarantee that a search seeing a fresh norm sees the fully written vector it belongs to.
+     */
+    struct cosine_norm_t {
+        std::atomic<std::uint32_t> bits;
+        inline std::uint32_t load(std::memory_order order) const noexcept { return bits.load(order); }
+        inline void store(std::uint32_t value, std::memory_order order) noexcept { bits.store(value, order); }
+    };
+    using cosine_norms_allocator_t = aligned_allocator_gt<cosine_norm_t, 64>;
+    using cosine_norms_t = buffer_gt<cosine_norm_t, cosine_norms_allocator_t>;
+    enum : std::uint32_t { invalid_cosine_norm_bits_k = 0x7fc00000u };
+    static_assert(sizeof(cosine_norm_t) == sizeof(std::uint32_t), "Sidecar entries must stay four bytes");
+    // Lock-freedom guard, C++11-compatible. `is_always_lock_free` is C++17; its definition is "the
+    // `ATOMIC_xxx_LOCK_FREE` macro of the same type equals 2", so on older standards the macro is selected by
+    // exact type identity (`std::is_same`), never by size: lock-freedom is a per-type property. If `std::uint32_t`
+    // is an extended integer type with no macro of its own, the property can't be evaluated before C++17, so the
+    // guard is skipped there; correctness never depends on it, only the hot-path cost, and every C++17 build of
+    // the same headers still checks it. The public headers advertise C++11 support and must not use C++17-only
+    // members.
+#if __cplusplus >= 201703L
+    static_assert(std::atomic<std::uint32_t>::is_always_lock_free, "Sidecar entries must be lock-free");
+#else
+    enum : int {
+        cosine_norm_lock_free_k = std::is_same<std::uint32_t, unsigned int>::value         ? ATOMIC_INT_LOCK_FREE
+                                  : std::is_same<std::uint32_t, unsigned long>::value      ? ATOMIC_LONG_LOCK_FREE
+                                  : std::is_same<std::uint32_t, unsigned short>::value     ? ATOMIC_SHORT_LOCK_FREE
+                                  : std::is_same<std::uint32_t, unsigned long long>::value ? ATOMIC_LLONG_LOCK_FREE
+                                  : std::is_same<std::uint32_t, unsigned char>::value      ? ATOMIC_CHAR_LOCK_FREE
+                                                                                           : -1
+    };
+    static_assert(cosine_norm_lock_free_k == 2 || cosine_norm_lock_free_k == -1, "Sidecar entries must be lock-free");
+#endif
+
     /// @brief Punned metric object.
     class metric_proxy_t {
         index_dense_gt const* index_ = nullptr;
@@ -453,6 +495,49 @@ class index_dense_gt {
         inline byte_t const* v(member_cref_t m) const noexcept { return index_->vectors_lookup_[get_slot(m)]; }
         inline byte_t const* v(member_citerator_t m) const noexcept { return index_->vectors_lookup_[get_slot(m)]; }
         inline distance_t f(byte_t const* a, byte_t const* b) const noexcept { return index_->metric_(a, b); }
+    };
+
+    /// @brief Search-only metric proxy using a prepared query norm and member norms addressed by dense slot.
+    class metric_proxy_cosine_norms_t {
+        index_dense_gt const* index_ = nullptr;
+        f32_t query_norm_ = 0;
+
+      public:
+        metric_proxy_cosine_norms_t(index_dense_gt const& index, f32_t query_norm) noexcept
+            : index_(&index), query_norm_(query_norm) {}
+
+        inline distance_t operator()(byte_t const* a, member_cref_t b) const noexcept { return f(a, b); }
+        inline distance_t operator()(member_cref_t a, member_cref_t b) const noexcept {
+            return index_->metric_(v(a), v(b));
+        }
+
+        inline distance_t operator()(byte_t const* a, member_citerator_t b) const noexcept { return f(a, b); }
+        inline distance_t operator()(member_citerator_t a, member_citerator_t b) const noexcept {
+            return index_->metric_(v(a), v(b));
+        }
+
+        inline distance_t operator()(byte_t const* a, byte_t const* b) const noexcept {
+            return index_->metric_(a, b);
+        }
+
+        inline byte_t const* v(member_cref_t m) const noexcept { return index_->vectors_lookup_[get_slot(m)]; }
+        inline byte_t const* v(member_citerator_t m) const noexcept { return index_->vectors_lookup_[get_slot(m)]; }
+
+      private:
+        template <typename member_at> inline distance_t f(byte_t const* query, member_at member) const noexcept {
+            // The proxy is only constructed while `cosine_norm_cache_active_()` holds, so the sidecar is
+            // capacity-sized and every slot is in range. The writer only ever stores values accepted by
+            // `try_compute_cosine_norm` or the invalid sentinel, so one classification test is sufficient.
+            std::uint32_t member_norm_bits = index_->cosine_norms_[get_slot(member)].load(std::memory_order_acquire);
+            if (!metric_t::is_valid_cosine_norm_bits(member_norm_bits)) {
+                USEARCH_COSINE_NORM_CACHE_DIAGNOSTIC(invalid_fallback);
+                return index_->metric_(query, v(member));
+            }
+            USEARCH_COSINE_NORM_CACHE_DIAGNOSTIC(cache_hit);
+            f32_t member_norm = 0;
+            std::memcpy(&member_norm, &member_norm_bits, sizeof(member_norm));
+            return index_->metric_.cosine_distance_with_valid_norms(query, v(member), query_norm_, member_norm);
+        }
     };
 
     index_dense_config_t config_;
@@ -476,6 +561,10 @@ class index_dense_gt {
 
     /// @brief For every managed `compressed_slot_t` stores a pointer to the allocated vector copy.
     mutable vectors_lookup_t vectors_lookup_;
+
+    /// @brief Raw f32 L2-norm bits (or the invalid sentinel) per capacity slot, for owned vectors in the
+    ///        eligible built-in cosine route. Empty when the route is ineligible; capacity-sized otherwise.
+    cosine_norms_t cosine_norms_;
 
     using available_threads_allocator_t = aligned_allocator_gt<std::size_t, 64>;
     using available_threads_t = ring_gt<std::size_t, available_threads_allocator_t>;
@@ -595,6 +684,7 @@ class index_dense_gt {
 
           vectors_tape_allocator_(std::move(other.vectors_tape_allocator_)), //
           vectors_lookup_(std::move(other.vectors_lookup_)),                 //
+          cosine_norms_(std::move(other.cosine_norms_)),                     //
 
           available_threads_(std::move(other.available_threads_)), //
           slot_lookup_(std::move(other.slot_lookup_)),             //
@@ -620,6 +710,7 @@ class index_dense_gt {
 
         std::swap(vectors_tape_allocator_, other.vectors_tape_allocator_);
         std::swap(vectors_lookup_, other.vectors_lookup_);
+        std::swap(cosine_norms_, other.cosine_norms_);
 
         std::swap(available_threads_, other.available_threads_);
         std::swap(slot_lookup_, other.slot_lookup_);
@@ -740,8 +831,29 @@ class index_dense_gt {
                 return false;
             cast_buffer_ = std::move(new_buffer);
         }
+
+        // Rebuild the cosine norm sidecar for the new metric before committing anything, so that an allocation
+        // failure leaves the index untouched. Norms are preserved verbatim when the old and new metrics are both
+        // cache-eligible over the same scalars and dimensions, and recomputed with the new metric otherwise.
+        bool new_cache_eligible = cosine_norm_cache_eligible_for_(metric);
+        bool preserve_norms = new_cache_eligible && cosine_norm_cache_active_() &&
+                              metric.dimensions() == metric_.dimensions() &&
+                              metric.scalar_kind() == metric_.scalar_kind();
+        cosine_norms_t replacement_norms;
+        if (new_cache_eligible && !preserve_norms && vectors_lookup_.size()) {
+            replacement_norms = cosine_norms_t(vectors_lookup_.size());
+            if (!replacement_norms)
+                return false;
+            cosine_norms_fill_invalid_(replacement_norms);
+            populate_cosine_norms_(replacement_norms, metric);
+        }
+
         casts_ = casts_punned_t::make(metric.scalar_kind());
         metric_ = std::move(metric);
+        if (!new_cache_eligible)
+            cosine_norms_.reset();
+        else if (!preserve_norms)
+            cosine_norms_ = std::move(replacement_norms);
         return true;
     }
 
@@ -827,7 +939,8 @@ class index_dense_gt {
             typed_->memory_usage(0) +                   //
             typed_->tape_allocator().total_wasted() +   //
             typed_->tape_allocator().total_reserved() + //
-            vectors_tape_allocator_.total_allocated();
+            vectors_tape_allocator_.total_allocated() + //
+            cosine_norms_.size() * sizeof(cosine_norm_t);
     }
 
     /**
@@ -1062,15 +1175,34 @@ class index_dense_gt {
         }
 
         // Hash-table load-factor slack does not need corresponding vector or graph slots.
+        vectors_lookup_t new_vectors_lookup;
         if (limits.members != vectors_lookup_.size()) {
-            vectors_lookup_t new_vectors_lookup(limits.members);
+            new_vectors_lookup = vectors_lookup_t(limits.members);
             if (!new_vectors_lookup)
                 return false;
             if (vectors_lookup_.size() > 0)
                 std::memcpy(new_vectors_lookup.data(), vectors_lookup_.data(),
                             vectors_lookup_.size() * sizeof(byte_t*));
-            vectors_lookup_ = std::move(new_vectors_lookup);
         }
+
+        // Mapped and vector-less indexes stay allocation-free on this route. Mutable eligible indexes keep a
+        // capacity-sized sidecar, initialized with an integer sentinel for all new or otherwise uncertain slots.
+        bool cache_eligible = cosine_norm_cache_eligible_();
+        cosine_norms_t new_cosine_norms;
+        if (cache_eligible && limits.members != cosine_norms_.size()) {
+            new_cosine_norms = cosine_norms_t(limits.members);
+            if (limits.members && !new_cosine_norms)
+                return false;
+            cosine_norms_fill_invalid_(new_cosine_norms);
+            cosine_norms_copy_(new_cosine_norms, cosine_norms_, (std::min)(cosine_norms_.size(), new_cosine_norms.size()));
+        }
+
+        if (new_vectors_lookup)
+            vectors_lookup_ = std::move(new_vectors_lookup);
+        if (!cache_eligible)
+            cosine_norms_.reset();
+        else if (new_cosine_norms)
+            cosine_norms_ = std::move(new_cosine_norms);
 
         // During reserve, no insertions may be happening, so we can safely overwrite the whole collection.
         std::unique_lock<std::mutex> available_threads_lock(available_threads_mutex_);
@@ -1111,6 +1243,7 @@ class index_dense_gt {
         slot_lookup_.clear();
         // Tape pointers are about to be invalidated by the reset below.
         std::fill(vectors_lookup_.begin(), vectors_lookup_.end(), nullptr);
+        cosine_norms_fill_invalid_(cosine_norms_);
         free_keys_.clear();
         vectors_tape_allocator_.reset();
     }
@@ -1132,6 +1265,7 @@ class index_dense_gt {
             typed_->reset();
         slot_lookup_.clear();
         vectors_lookup_.reset();
+        cosine_norms_.reset();
         free_keys_.clear();
         vectors_tape_allocator_.reset();
         available_threads_.reset();
@@ -1334,6 +1468,8 @@ class index_dense_gt {
         available_threads_ = std::move(available_threads);
 
         reindex_keys_();
+        if (!try_rebuild_cosine_norms_(!config.exclude_vectors))
+            return result.failed("Failed to allocate memory for cosine norms");
         return result;
     }
 
@@ -1664,6 +1800,9 @@ class index_dense_gt {
             compressed_slot_t slot = (*slots_it).slot;
             free_keys_.push(slot);
             typed_->at(slot).key = free_key_;
+            if (static_cast<std::size_t>(slot) < cosine_norms_.size())
+                cosine_norms_[slot].store(static_cast<std::uint32_t>(invalid_cosine_norm_bits_k),
+                                          std::memory_order_release);
         }
         slot_lookup_.erase(key);
         result.completed = matching_count;
@@ -1708,6 +1847,9 @@ class index_dense_gt {
                 compressed_slot_t slot = (*slots_it).slot;
                 free_keys_.push(slot);
                 typed_->at(slot).key = free_key_;
+                if (static_cast<std::size_t>(slot) < cosine_norms_.size())
+                    cosine_norms_[slot].store(static_cast<std::uint32_t>(invalid_cosine_norm_bits_k),
+                                              std::memory_order_release);
                 ++matching_count;
             }
 
@@ -1813,6 +1955,16 @@ class index_dense_gt {
 
         copy.slot_lookup_ = slot_lookup_; // TODO: Handle out of memory
         *copy.typed_ = std::move(typed_result.index);
+        // Slots are preserved by `copy`, so a valid source sidecar can be duplicated instead of recomputed.
+        bool vectors_owned = config.force_vector_copy || !copy.config_.exclude_vectors;
+        if (vectors_owned && cosine_norm_cache_active_() && copy.cosine_norm_cache_eligible_() &&
+            cosine_norms_.size() == copy.vectors_lookup_.size()) {
+            copy.cosine_norms_ = cosine_norms_t(cosine_norms_.size());
+            if (cosine_norms_.size() && !copy.cosine_norms_)
+                return result.failed("Out of memory!");
+            cosine_norms_copy_(copy.cosine_norms_, cosine_norms_, cosine_norms_.size());
+        } else if (!copy.try_rebuild_cosine_norms_(vectors_owned))
+            return result.failed("Out of memory!");
         return result;
     }
 
@@ -1911,18 +2063,39 @@ class index_dense_gt {
         if (!new_vectors_lookup)
             return result.failed("Out of memory!");
 
+        bool cache_eligible = cosine_norm_cache_eligible_();
+        cosine_norms_t new_cosine_norms;
+        if (cache_eligible && vectors_lookup_.size()) {
+            new_cosine_norms = cosine_norms_t(vectors_lookup_.size());
+            if (!new_cosine_norms)
+                return result.failed("Out of memory!");
+            cosine_norms_fill_invalid_(new_cosine_norms);
+        }
+
         vectors_tape_allocator_t new_vectors_allocator;
 
-        auto track_slot_change = [&](vector_key_t, compressed_slot_t old_slot, compressed_slot_t new_slot) {
+        auto track_slot_change = [&](vector_key_t key, compressed_slot_t old_slot, compressed_slot_t new_slot) {
             byte_t* new_vector = new_vectors_allocator.allocate(metric_.bytes_per_vector());
             byte_t* old_vector = vectors_lookup_[old_slot];
             std::memcpy(new_vector, old_vector, metric_.bytes_per_vector());
             new_vectors_lookup[new_slot] = new_vector;
+            // Removed members are carried over by `compact` as well; their slots keep the sentinel, as after `remove`.
+            if (cache_eligible && key != free_key_) {
+                std::uint32_t norm_bits = invalid_cosine_norm_bits_k;
+                if (metric_.try_compute_cosine_norm(new_vector, norm_bits)) {
+                    new_cosine_norms[new_slot].store(norm_bits, std::memory_order_relaxed);
+                    USEARCH_COSINE_NORM_CACHE_DIAGNOSTIC(population);
+                }
+            }
         };
         typed_->compact(values_proxy_t{*this}, metric_proxy_t{*this}, track_slot_change,
                         std::forward<executor_at>(executor), std::forward<progress_at>(progress));
         vectors_lookup_ = std::move(new_vectors_lookup);
         vectors_tape_allocator_ = std::move(new_vectors_allocator);
+        if (cache_eligible)
+            cosine_norms_ = std::move(new_cosine_norms);
+        else
+            cosine_norms_.reset();
         return result;
     }
 
@@ -2212,6 +2385,8 @@ class index_dense_gt {
                 std::memcpy(vectors_lookup_[member.slot], vector_data, metric_.bytes_per_vector());
             } else
                 vectors_lookup_[member.slot] = (byte_t*)vector_data;
+            populate_cosine_norm_(static_cast<compressed_slot_t>(member.slot), vectors_lookup_[member.slot],
+                                  copy_vector);
         };
 
         index_update_config_t update_config;
@@ -2245,18 +2420,40 @@ class index_dense_gt {
         search_config.expansion = config_.expansion_search;
         search_config.exact = exact;
 
+        if (cosine_norm_cache_active_()) {
+            std::uint32_t query_norm_bits = invalid_cosine_norm_bits_k;
+            if (metric_.try_compute_cosine_norm(vector_data, query_norm_bits)) {
+                USEARCH_COSINE_NORM_CACHE_DIAGNOSTIC(query_preparation);
+                f32_t query_norm = 0;
+                std::memcpy(&query_norm, &query_norm_bits, sizeof(query_norm));
+                return search_with_metric_(vector_data, wanted, std::forward<predicate_at>(predicate), search_config,
+                                           metric_proxy_cosine_norms_t{*this, query_norm}, std::move(lock));
+            }
+            USEARCH_COSINE_NORM_CACHE_DIAGNOSTIC(invalid_fallback);
+        }
+        USEARCH_COSINE_NORM_CACHE_DIAGNOSTIC(route_bypass);
+        return search_with_metric_(vector_data, wanted, std::forward<predicate_at>(predicate), search_config,
+                                   metric_proxy_t{*this}, std::move(lock));
+    }
+
+    template <typename predicate_at, typename metric_at>
+    search_result_t search_with_metric_(byte_t const* vector_data, std::size_t wanted, predicate_at&& predicate,
+                                        index_search_config_t const& search_config, metric_at&& metric,
+                                        thread_lock_t lock) const {
         vector_key_t free_key_copy = free_key_;
         if (std::is_same<typename std::decay<predicate_at>::type, dummy_predicate_t>::value) {
             auto allow = [free_key_copy](member_cref_t const& member) noexcept {
                 return (vector_key_t)member.key != free_key_copy;
             };
-            auto typed_result = typed_->search(vector_data, wanted, metric_proxy_t{*this}, search_config, allow);
+            auto typed_result =
+                typed_->search(vector_data, wanted, std::forward<metric_at>(metric), search_config, allow);
             return search_result_t{std::move(typed_result), std::move(lock)};
         } else {
             auto allow = [free_key_copy, &predicate](member_cref_t const& member) noexcept {
                 return (vector_key_t)member.key != free_key_copy && predicate(member.key);
             };
-            auto typed_result = typed_->search(vector_data, wanted, metric_proxy_t{*this}, search_config, allow);
+            auto typed_result =
+                typed_->search(vector_data, wanted, std::forward<metric_at>(metric), search_config, allow);
             return search_result_t{std::move(typed_result), std::move(lock)};
         }
     }
@@ -2334,6 +2531,94 @@ class index_dense_gt {
 
         result.mean /= result.count;
         return result;
+    }
+
+    /**
+     *  @brief  Whether `metric` qualifies for the cosine norm sidecar on this index: the built-in auto-vectorized
+     *          f32/bf16 cosine kernel, owned vectors, and a mutable (not memory-mapped) graph.
+     */
+    bool cosine_norm_cache_eligible_for_(metric_t const& metric) const noexcept {
+        return metric.supports_cosine_norm_cache() && !config_.exclude_vectors && typed_ && !typed_->is_immutable();
+    }
+
+    bool cosine_norm_cache_eligible_() const noexcept { return cosine_norm_cache_eligible_for_(metric_); }
+
+    /// @brief Whether searches may use the sidecar: eligible and sized to the current capacity.
+    bool cosine_norm_cache_active_() const noexcept {
+        return cosine_norm_cache_eligible_() && cosine_norms_.size() == vectors_lookup_.size();
+    }
+
+    void populate_cosine_norm_(compressed_slot_t slot, byte_t const* vector, bool vector_owned) noexcept {
+        std::size_t slot_index = static_cast<std::size_t>(slot);
+        if (slot_index >= cosine_norms_.size())
+            return;
+        cosine_norms_[slot_index].store(static_cast<std::uint32_t>(invalid_cosine_norm_bits_k),
+                                        std::memory_order_release);
+        if (!vector_owned || !vector) {
+            USEARCH_COSINE_NORM_CACHE_DIAGNOSTIC(route_bypass);
+            return;
+        }
+
+        std::uint32_t norm_bits = invalid_cosine_norm_bits_k;
+        if (metric_.try_compute_cosine_norm(vector, norm_bits)) {
+            // Release: the vector bytes at this slot were written before this store, and a search that acquires
+            // this value may read them afterwards.
+            cosine_norms_[slot_index].store(norm_bits, std::memory_order_release);
+            USEARCH_COSINE_NORM_CACHE_DIAGNOSTIC(population);
+        }
+    }
+
+    static void cosine_norms_fill_invalid_(cosine_norms_t& norms) noexcept {
+        for (std::size_t i = 0; i != norms.size(); ++i)
+            norms[i].store(static_cast<std::uint32_t>(invalid_cosine_norm_bits_k), std::memory_order_relaxed);
+    }
+
+    static void cosine_norms_copy_(cosine_norms_t& to, cosine_norms_t const& from, std::size_t count) noexcept {
+        for (std::size_t i = 0; i != count; ++i)
+            to[i].store(from[i].load(std::memory_order_relaxed), std::memory_order_relaxed);
+    }
+
+    /**
+     *  @brief  Fills a capacity-sized, sentinel-initialized sidecar with the norms of all live members, using the
+     *          supplied metric (which may differ from `metric_` while a metric change is being prepared).
+     *          No locking: callers guarantee no concurrent insertions.
+     */
+    void populate_cosine_norms_(cosine_norms_t& norms, metric_t const& metric) const noexcept {
+        std::size_t slots_count = (std::min)(typed_->size(), (std::min)(vectors_lookup_.size(), norms.size()));
+        for (std::size_t slot = 0; slot != slots_count; ++slot) {
+            if (typed_->at(static_cast<compressed_slot_t>(slot)).key == free_key_)
+                continue;
+            byte_t const* vector = vectors_lookup_[slot];
+            std::uint32_t norm_bits = invalid_cosine_norm_bits_k;
+            if (vector && metric.try_compute_cosine_norm(vector, norm_bits)) {
+                norms[slot].store(norm_bits, std::memory_order_relaxed);
+                USEARCH_COSINE_NORM_CACHE_DIAGNOSTIC(population);
+            }
+        }
+    }
+
+    /// @brief Drops the sidecar and, if the route is eligible and vectors are owned, rebuilds it from scratch.
+    bool try_rebuild_cosine_norms_(bool vectors_owned) noexcept {
+        if (!cosine_norm_cache_eligible_()) {
+            cosine_norms_.reset();
+            return true;
+        }
+
+        cosine_norms_t rebuilt;
+        if (vectors_lookup_.size()) {
+            rebuilt = cosine_norms_t(vectors_lookup_.size());
+            if (!rebuilt)
+                return false;
+            cosine_norms_fill_invalid_(rebuilt);
+        }
+        cosine_norms_ = std::move(rebuilt);
+
+        if (!vectors_owned) {
+            USEARCH_COSINE_NORM_CACHE_DIAGNOSTIC(route_bypass);
+            return true;
+        }
+        populate_cosine_norms_(cosine_norms_, metric_);
+        return true;
     }
 
     void reindex_keys_() {

--- a/include/usearch/index_plugins.hpp
+++ b/include/usearch/index_plugins.hpp
@@ -3016,6 +3016,123 @@ class metric_punned_t {
         return divide_round_up(dimensions_ * bits_per_scalar(scalar_kind_), bits_per_scalar_word(scalar_kind_));
     }
 
+    /**
+     *  @brief  Whether this metric is the built-in auto-vectorized f32/bf16 cosine kernel, for which the
+     *          `index_dense_gt` norm cache is applicable.
+     *
+     *  Provenance is established by the identity of the routed kernel itself: `metric_ptr_` must be the address of
+     *  the exact `metric_cos_gt` instantiation that `configure_with_autovec` installs, and the third argument must be
+     *  the dimensions count that kernel expects. This deliberately does not rely on the identity of the
+     *  member-function trampoline (`metric_routed_`): trampolines with identical bodies can be folded to one address
+     *  by identical-code-folding linkers (MSVC `/OPT:ICF`, `gold`/`lld` `--icf=all`), which would make a cosine-labelled
+     *  user callback with the `array_array_size` signature indistinguishable from the built-in kernel. The two cosine
+     *  kernels compared against here have distinct bodies from every other kernel, so they cannot be folded into
+     *  anything else. User callbacks and NumKong kernels never satisfy this predicate.
+     */
+    inline bool supports_cosine_norm_cache() const noexcept {
+        if (metric_kind_ != metric_kind_t::cos_k || !metric_ptr_ || metric_third_arg_ != dimensions_)
+            return false;
+        if (scalar_kind_ == scalar_kind_t::f32_k)
+            return metric_ptr_ == (uptr_t)&equidimensional_<metric_cos_gt<f32_t>>;
+        if (scalar_kind_ == scalar_kind_t::bf16_k)
+            return metric_ptr_ == (uptr_t)&equidimensional_<metric_cos_gt<bf16_t, f32_t>>;
+        return false;
+    }
+
+    /**
+     *  @brief  Computes the f32 L2 norm (square root of the sum of squares) of a vector and exports its raw bits.
+     *  @return `false` for unsupported metrics, non-finite inputs, or an overflowing sum of squares.
+     *
+     *  The square root is taken once here, so that searches only pay one multiply and one division per comparison,
+     *  and the resulting expression `1 - ab / (a_norm * b_norm)` is algebraically the same as `metric_cos_gt`'s
+     *  `1 - ab / (sqrt(a2) * sqrt(b2))`. All classification is performed on integer bit patterns. This is important
+     *  in translation units compiled with `-ffast-math`, where floating-point finiteness predicates aren't reliable
+     *  correctness guards.
+     */
+    inline bool try_compute_cosine_norm(byte_t const* vector, std::uint32_t& norm_bits) const noexcept {
+        norm_bits = 0x7fc00000u;
+        if (!supports_cosine_norm_cache() || !vector)
+            return false;
+
+        f32_t squared_norm = 0;
+        if (scalar_kind_ == scalar_kind_t::f32_k) {
+            f32_t const* typed = reinterpret_cast<f32_t const*>(vector);
+            if (!cosine_all_finite_(typed, dimensions_))
+                return false;
+            squared_norm = cosine_squared_norm_(typed, dimensions_);
+        } else {
+            bf16_t const* typed = reinterpret_cast<bf16_t const*>(vector);
+            if (!cosine_all_finite_(typed, dimensions_))
+                return false;
+            squared_norm = cosine_squared_norm_(typed, dimensions_);
+        }
+
+        // Launder the accumulator through a volatile object before inspecting its representation: the volatile
+        // store and the volatile read-back are both observable side effects, so a fast-math build can neither
+        // assume the value is finite nor forward the (possibly poisoned) register value past this point.
+        volatile f32_t stored_norm = squared_norm;
+        f32_t laundered_norm = stored_norm;
+        std::uint32_t squared_bits = 0;
+        std::memcpy(&squared_bits, &laundered_norm, sizeof(squared_bits));
+        if ((squared_bits & 0x7f800000u) == 0x7f800000u || (squared_bits & 0x80000000u))
+            return false;
+
+        // The square root of a finite non-negative value is finite and non-negative, so no further checks apply.
+        volatile f32_t stored_root = std::sqrt(laundered_norm);
+        f32_t laundered_root = stored_root;
+        std::memcpy(&norm_bits, &laundered_root, sizeof(norm_bits));
+        return true;
+    }
+
+    /**
+     *  @brief  Whether a bit pattern produced by `try_compute_cosine_norm` (or the invalid sentinel) denotes a usable
+     *          norm. Exactly the values `try_compute_cosine_norm` can export pass this test.
+     */
+    inline static bool is_valid_cosine_norm_bits(std::uint32_t norm_bits) noexcept {
+        return (norm_bits & 0x7f800000u) != 0x7f800000u && !(norm_bits & 0x80000000u);
+    }
+
+    /**
+     *  @brief  Cosine distance using norms already computed by `try_compute_cosine_norm`. Precondition: both norms
+     *          passed `is_valid_cosine_norm_bits` and `supports_cosine_norm_cache()` holds; no checks are repeated.
+     *
+     *  Zero handling exactly matches `metric_cos_gt`: two zero vectors have distance zero and exactly one zero
+     *  vector has distance one.
+     */
+    inline result_t cosine_distance_with_valid_norms(byte_t const* a, byte_t const* b, f32_t a_norm,
+                                                     f32_t b_norm) const noexcept {
+        f32_t ab = scalar_kind_ == scalar_kind_t::f32_k
+                       ? cosine_dot_(reinterpret_cast<f32_t const*>(a), reinterpret_cast<f32_t const*>(b), dimensions_)
+                       : cosine_dot_(reinterpret_cast<bf16_t const*>(a), reinterpret_cast<bf16_t const*>(b),
+                                     dimensions_);
+        // Zero tests on the bit patterns, so that `-ffast-math` can't turn them into something else.
+        std::uint32_t a_bits = 0, b_bits = 0;
+        std::memcpy(&a_bits, &a_norm, sizeof(a_bits));
+        std::memcpy(&b_bits, &b_norm, sizeof(b_bits));
+        bool a_is_zero = (a_bits & 0x7fffffffu) == 0;
+        bool b_is_zero = (b_bits & 0x7fffffffu) == 0;
+        if (a_is_zero)
+            return b_is_zero ? 0 : 1;
+        if (b_is_zero)
+            return 1;
+        return 1 - ab / (a_norm * b_norm);
+    }
+
+    /**
+     *  @brief  Checked convenience wrapper over `cosine_distance_with_valid_norms`, falling back to the full metric
+     *          for unsupported metrics or invalid norm bits.
+     */
+    inline result_t cosine_distance_with_norms(byte_t const* a, byte_t const* b, std::uint32_t a_norm_bits,
+                                               std::uint32_t b_norm_bits) const noexcept {
+        if (!supports_cosine_norm_cache() || !is_valid_cosine_norm_bits(a_norm_bits) ||
+            !is_valid_cosine_norm_bits(b_norm_bits))
+            return (*this)(a, b);
+        f32_t a_norm = 0, b_norm = 0;
+        std::memcpy(&a_norm, &a_norm_bits, sizeof(a_norm));
+        std::memcpy(&b_norm, &b_norm_bits, sizeof(b_norm));
+        return cosine_distance_with_valid_norms(a, b, a_norm, b_norm);
+    }
+
   private:
 #if USEARCH_USE_NUMKONG
     /**
@@ -3105,6 +3222,85 @@ class metric_punned_t {
         result_t result = function_pointer(a, b);
         return result;
     }
+    /// @brief Integer-only finiteness scan; vectorizable, unlike an early-exit loop.
+    inline static bool cosine_all_finite_(f32_t const* vector, std::size_t dimensions) noexcept {
+        std::uint32_t nonfinite = 0;
+        for (std::size_t i = 0; i != dimensions; ++i) {
+            std::uint32_t scalar_bits = 0;
+            std::memcpy(&scalar_bits, vector + i, sizeof(scalar_bits));
+            nonfinite |= (scalar_bits & 0x7f800000u) == 0x7f800000u;
+        }
+        return !nonfinite;
+    }
+
+    inline static bool cosine_all_finite_(bf16_t const* vector, std::size_t dimensions) noexcept {
+        std::uint32_t nonfinite = 0;
+        for (std::size_t i = 0; i != dimensions; ++i) {
+            std::uint16_t scalar_bits = 0;
+            std::memcpy(&scalar_bits, vector + i, sizeof(scalar_bits));
+            nonfinite |= (scalar_bits & 0x7f80u) == 0x7f80u;
+        }
+        return !nonfinite;
+    }
+
+    inline static f32_t cosine_squared_norm_(f32_t const* vector, std::size_t dimensions) noexcept {
+        f32_t norm = 0;
+#if USEARCH_USE_OPENMP
+#pragma omp simd reduction(+ : norm)
+#elif defined(USEARCH_DEFINED_CLANG)
+#pragma clang loop vectorize(enable)
+#elif defined(USEARCH_DEFINED_GCC)
+#pragma GCC ivdep
+#endif
+        for (std::size_t i = 0; i != dimensions; ++i)
+            norm += vector[i] * vector[i];
+        return norm;
+    }
+
+    inline static f32_t cosine_squared_norm_(bf16_t const* vector, std::size_t dimensions) noexcept {
+        f32_t norm = 0;
+#if USEARCH_USE_OPENMP
+#pragma omp simd reduction(+ : norm)
+#elif defined(USEARCH_DEFINED_CLANG)
+#pragma clang loop vectorize(enable)
+#elif defined(USEARCH_DEFINED_GCC)
+#pragma GCC ivdep
+#endif
+        for (std::size_t i = 0; i != dimensions; ++i) {
+            f32_t scalar = static_cast<f32_t>(vector[i]);
+            norm += scalar * scalar;
+        }
+        return norm;
+    }
+
+    inline static f32_t cosine_dot_(f32_t const* a, f32_t const* b, std::size_t dimensions) noexcept {
+        f32_t dot = 0;
+#if USEARCH_USE_OPENMP
+#pragma omp simd reduction(+ : dot)
+#elif defined(USEARCH_DEFINED_CLANG)
+#pragma clang loop vectorize(enable)
+#elif defined(USEARCH_DEFINED_GCC)
+#pragma GCC ivdep
+#endif
+        for (std::size_t i = 0; i != dimensions; ++i)
+            dot += a[i] * b[i];
+        return dot;
+    }
+
+    inline static f32_t cosine_dot_(bf16_t const* a, bf16_t const* b, std::size_t dimensions) noexcept {
+        f32_t dot = 0;
+#if USEARCH_USE_OPENMP
+#pragma omp simd reduction(+ : dot)
+#elif defined(USEARCH_DEFINED_CLANG)
+#pragma clang loop vectorize(enable)
+#elif defined(USEARCH_DEFINED_GCC)
+#pragma GCC ivdep
+#endif
+        for (std::size_t i = 0; i != dimensions; ++i)
+            dot += static_cast<f32_t>(a[i]) * static_cast<f32_t>(b[i]);
+        return dot;
+    }
+
     void configure_with_autovec() noexcept {
         switch (metric_kind_) {
         case metric_kind_t::ip_k: {


### PR DESCRIPTION
Closes #786.

## Summary

This PR speeds up built-in f32/bf16 cosine HNSW search by caching one f32 L2 norm for every owned member-vector
slot. The query norm is computed once per search; candidate comparisons reuse the member norm and only perform the
dot product plus final normalization.

The sidecar is enabled only when all of the following hold:

- the configured metric is USearch's built-in auto-vectorized cosine kernel;
- stored vectors are f32 or bf16;
- the index owns its vectors and the graph is mutable; and
- NumKong is not supplying the metric kernel.

Custom callbacks, NumKong kernels, mapped views, external-vector indexes, unsupported scalar kinds, and non-finite
norms retain the existing metric route.

## Implementation

Each sidecar entry is a lock-free atomic 32-bit value containing the raw bits of the member's f32 L2 norm or an
invalid sentinel. Insertions publish norms with release stores after vector bytes are written, and searches consume
them with acquire loads before reading those bytes. Maintenance operations that exclude concurrent mutation use
relaxed atomic accesses.

The sidecar follows the complete index lifecycle:

- reserve grows it with index capacity;
- add/update populates the affected slot;
- remove and clear invalidate slots;
- compact remaps and repopulates live slots;
- copy duplicates a valid sidecar without recomputing it;
- load rebuilds it; views deliberately bypass it;
- metric changes allocate and populate replacement state before committing, preserve compatible cosine state, or
  release it when the new metric is ineligible.

The sidecar is not serialized, so index file bytes and the on-disk format remain unchanged.

Metric provenance uses the address of the exact built-in cosine kernel installed by `configure_with_autovec`, plus
the expected dimension argument. It does not compare the generic routing trampoline, which an ICF linker can merge
with another identical trampoline. This prevents a cosine-labelled user callback from being mistaken for the
built-in implementation.

The public-header lock-freedom assertion remains C++11-compatible: pre-C++17 builds select the matching
`ATOMIC_*_LOCK_FREE` macro using exact type identity, while C++17 and newer use
`std::atomic<std::uint32_t>::is_always_lock_free`.

## Performance

The controlled benchmark loads the same baseline-built Wiki-1M cosine index in both binaries, so the HNSW graph is
identical. It uses one pinned CPU, a warm-up pass, 1,024 held-out queries, 16 timed repeats, k=10, and seven paired
rounds.

| Compiler | Baseline median QPS | Patched median QPS | Paired median gain | 95% bootstrap interval | Positive rounds |
|---|---:|---:|---:|---:|---:|
| GCC 11.4 | 3,785.3 | 4,445.0 | **+17.54%** | +17.14% to +17.76% | 7/7 |
| GCC 13.4 | 3,718.5 | 4,000.0 | **+7.41%** | +7.20% to +7.61% | 7/7 |

Computed distances (926.5/query) and visited members (75.8/query) are unchanged in every timed row.

Memory increases from 1,333,418,176 to 1,337,418,176 bytes at one million slots: exactly four bytes per slot.
Loading rises from approximately 0.92-0.94 s to 1.04-1.05 s because the sidecar is rebuilt. Three alternating
96-thread builds measured 10.4, 10.2, 10.5 s on baseline and 10.2, 10.1, 10.2 s patched, showing no measurable
construction regression.

The optimization is intentionally inactive when NumKong supplies cosine. The throughput claim therefore applies to
the built-in auto-vectorized route, not NumKong-enabled builds.

## Correctness and tests

- Release C and full C++ suites pass with GCC 11 and GCC 13 when NumKong is disabled.
- The public-header smoke test passes under C++11, C++14, C++17, and C++20.
- Full C++ tests pass when linked with gold `--icf=all`.
- C and full C++ suites pass with ASan, LSan, UBSan, and alignment sanitization.
- A scaled 300 x 128 f32/bf16 lifecycle test passes under the same sanitizers.
- ThreadSanitizer no longer reports a sidecar or diagnostic-counter race. It still reports pre-existing upstream
  HNSW graph races under concurrent add/search; this PR does not claim to make that broader operation race-free.
- With NumKong enabled, the C suite, focused f32/bf16 cache tests, and an independent bypass probe pass and confirm
  that no sidecar route is used.
- Tests cover f32/bf16 distance values, zero-vector semantics, query casting, filtering, non-finite fallback,
  custom callbacks, metric changes, remove/reinsert, clear, compact, copy, save/load/view, memory accounting, and
  concurrent sidecar publication.

Result parity was also compared over 10,240 Wiki-1M top-k outputs. GCC 11 changed four ordered positions across two
queries without changing either neighbor set; GCC 13 changed twelve ordered positions across two queries and one
top-10 boundary member. Maximum distance changes were `1.79e-7` and `4.10e-7`, with no non-finite mismatch. Recall
was unchanged with GCC 11 and moved from 0.98574 to 0.98564 with GCC 13 (0.01 percentage point).

## AI assistance

OpenAI Codex, configured with OpenAI `gpt-5.6-sol` at `xhigh` reasoning effort, produced the initial candidate.
 using `gpt-5.6-sol` at `max` reasoning effort was used to review, integrate, and validate the
contribution. 
I reviewed and understand every submitted change.
